### PR TITLE
Fix broken workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,7 +77,7 @@ jobs:
         run: pnpm check
 
       - name: Run tests
-        run: pnpm test run
+        run: pnpm test -- --coverage
 
       - name: Generate coverage badge
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
           fetch-depth: 0 # Needed for semantic-release to generate correct version numbers
           persist-credentials: false # Don't persist credentials to avoid potential security issues
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.0.0
+        with:
+          version: 10.4.1
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v4.0.2
         env:
@@ -32,12 +38,6 @@ jobs:
           node-version: lts/iron
           registry-url: https://registry.npmjs.org
           cache: pnpm
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4.0.0
-        with:
-          version: 10.4.1
-          run_install: false
 
       - name: Verify lockfile integrity
         run: |


### PR DESCRIPTION
The release workflow is failing on a missing `pnpm` executable. This changes the order of installing node and pnpm.