### PR TITLE
Fixs bug in release pipeline

### DIFF
--- a/scripts/create-version-pr.cjs
+++ b/scripts/create-version-pr.cjs
@@ -84,7 +84,7 @@ async function createVersionPR() {
 
     // Commit the changes
     exec(
-      `git commit -m "chore(release): update version to ${newVersion} [skip ci]"`,
+      `git commit --no-verify -m "chore(release): update version to ${newVersion} [skip ci]"`,
     )
 
     // Push the branch


### PR DESCRIPTION
The PR opening step in the commit pipeline is unexpectedly running tests because of the pre-commit hook. This disables the tests from running.