### PR TITLE
Fix missing coverage in checks on main

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,7 +78,7 @@ jobs:
         run: pnpm check
 
       - name: Run tests
-        run: pnpm test -- --coverage
+        run: pnpm test:coverage
 
       - name: Generate coverage badge
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,8 +3,12 @@ name: CodeQL Analysis
 on:
   push:
     branches: ["main", "release"]
+    paths:
+      - "src/**"
   pull_request:
     branches: ["main"]
+    paths:
+      - "src/**"
   schedule:
     - cron: "0 0 * * 0" # Run once a week on Sunday
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "build": "tsup",
     "check": "tsc --noEmit",
     "test": "vitest",
+    "test:coverage": "vitest --coverage",
     "prepack": "pnpm build",
     "commitlint": "commitlint --edit"
   },


### PR DESCRIPTION
Checks are failing on `main` because coverage isn't being generated. This reworks the command to make it run more reliably.