### PR TITLE
minor: publish middleware with provenance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We currently support the following versions with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| > 2.x   | :white_check_mark: |
-| < 2.x   | :x:                |
+| > 1.2.x | :white_check_mark: |
+| < 1.2.x | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
This gets us back on track with the release workflow. `Version 1.2.x` and above are published with provenance attestations.