### PR TITLE
Remove `gh auth` command in checks since we are already authed in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -108,9 +108,6 @@ jobs:
             git push origin $BRANCH_NAME
 
             # Create a pull request using GitHub CLI
-            # Authenticate with GitHub CLI using the GITHUB_TOKEN
-            echo "$GITHUB_TOKEN" | gh auth login --with-token
-
             gh pr create \
               --base main \
               --head $BRANCH_NAME \


### PR DESCRIPTION
This removes an explicit `gh auth` line from the checks workflow to clear up an auth error due to already being logged in.