### PR TITLE
Remove paths from codeql analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,12 +3,8 @@ name: CodeQL Analysis
 on:
   push:
     branches: ["main", "release"]
-    paths:
-      - "src/**"
   pull_request:
     branches: ["main"]
-    paths:
-      - "src/**"
   schedule:
     - cron: "0 0 * * 0" # Run once a week on Sunday
 


### PR DESCRIPTION
CodeQL analysis isn't triggering for some reason and we added a `paths` filter in an attempt to fix it, but it had no effect. This removes the filter.