### PR TITLE
patch: fix 403 in release pipeline

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -47,7 +47,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "node scripts/prepare-github-package.cjs",
-        "publishCmd": "npm publish --userconfig .npmrc --tag ${nextRelease.channel} --registry https://npm.pkg.github.com/ --no-git-tag-version"
+        "publishCmd": "npm publish --userconfig .npmrc --tag ${nextRelease.channel} --registry https://npm.pkg.github.com/ --no-git-tag-version --access public"
       }
     ],
     [

--- a/scripts/prepare-github-package.cjs
+++ b/scripts/prepare-github-package.cjs
@@ -14,14 +14,10 @@ const main = () => {
   // Read the current package.json
   const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8")
   const packageJson = JSON.parse(packageJsonContent)
-  // Add or update publishConfig for GitHub Packages
-  // Using 'restricted' access to make the package private on GitHub Packages
-  // for testing while keeping it public on npm registry
-  packageJson.private = true
+
   packageJson.publishConfig = {
-    ...packageJson.publishConfig,
     registry: "https://npm.pkg.github.com",
-    access: "restricted",
+    provenance: true,
   }
 
   // Write the modified package.json back to the build directory


### PR DESCRIPTION
We're running into release pipeline failures publishing to GH Packages. This tries to fix the 403.