### PR TITLE
patch: fix 403 in release pipeline

### DIFF
--- a/scripts/prepare-github-package.cjs
+++ b/scripts/prepare-github-package.cjs
@@ -17,6 +17,7 @@ const main = () => {
 
   packageJson.publishConfig = {
     registry: "https://npm.pkg.github.com",
+    access: "public",
     provenance: true,
   }
 


### PR DESCRIPTION
Adds public field to address 403 error when publishing to GH Packages 