### PR TITLE
fix: improve debug output formatting in appwarden-link

### DIFF
--- a/scripts/appwarden-link.cjs
+++ b/scripts/appwarden-link.cjs
@@ -856,7 +856,10 @@ async function main() {
   )
   if (writeOk) {
     print(`Wrote merged configuration to ${outPath}`)
-    debug(JSON.stringify(safeConfig, null, 2))
+    debug(
+      `Printing merged configuration\n`,
+      JSON.stringify(safeConfig, null, 2),
+    )
   } else {
     warn(`Failed to write merged configuration to ${outPath}`)
     process.exit(1)


### PR DESCRIPTION
Improves the debug log output when writing the merged configuration in `appwarden-link` by adding a descriptive label before the JSON output.

