### PR TITLE
fix: consolidate debug log message for merged configuration

### DIFF
--- a/scripts/appwarden-link.cjs
+++ b/scripts/appwarden-link.cjs
@@ -856,10 +856,7 @@ async function main() {
   )
   if (writeOk) {
     print(`Wrote merged configuration to ${outPath}`)
-    debug(
-      `Printing merged configuration\n`,
-      JSON.stringify(safeConfig, null, 2),
-    )
+    debug(`Logging merged configuration ${JSON.stringify(safeConfig, null, 2)}`)
   } else {
     warn(`Failed to write merged configuration to ${outPath}`)
     process.exit(1)


### PR DESCRIPTION
Consolidates the debug log output when writing the merged configuration in `appwarden-link` by combining the label and JSON into a single template literal argument.

This is a `fix:` commit and will trigger a patch release via semantic-release.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author