### PR TITLE
feat: prepare minor release 3.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "remixjs",
     "cloudflare",
     "web3",
-    "monitoring"
+    "monitoring",
+    "cli"
   ],
   "main": "./index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
This PR prepares for the minor release **3.16.0**.

When merged, semantic-release will detect the `feat` commit and trigger a minor version bump from `3.15.4` → `3.16.0`.

### Change
- Add `"cli"` keyword to `package.json` for improved npm discoverability of the `appwarden-link` CLI tool.
