### PR TITLE
fix(link): handle empty middleware array and empty config response

### DIFF
--- a/scripts/appwarden-link.cjs
+++ b/scripts/appwarden-link.cjs
@@ -591,6 +591,13 @@ function sanitizeRemoteConfig(data, depth = 0) {
     warn("Remote config nested too deeply. Truncating.")
     return null
   }
+  if (Array.isArray(data) && data.length === 0) {
+    warn(
+      "No Appwarden configuration was found for this domain. Are you sure the configuration exists and is committed to the domain configuration repository?",
+    )
+    return {}
+  }
+
   if (!data || typeof data !== "object" || Array.isArray(data)) {
     warn("Remote config response was not a valid object. Ignoring.")
     return null
@@ -705,6 +712,14 @@ async function fetchRemoteConfig(apiToken, apiHostname, fqdn) {
           fqdn === `www.${item.url}`,
       )
       config = entry?.options ?? null
+      if (
+        config === null &&
+        entry &&
+        Array.isArray(entry.middleware) &&
+        entry.middleware.length === 0
+      ) {
+        config = []
+      }
     } else if (data && typeof data === "object" && !Array.isArray(data)) {
       // Fallback: API returned a flat object directly
       config = data


### PR DESCRIPTION
This patch fixes two edge cases in `scripts/appwarden-link.cjs`:

1. `sanitizeRemoteConfig` now returns `{}` instead of `null` when the API responds with an empty array, so the script does not silently fall back to ignoring the config.
2. `fetchRemoteConfig` now treats an empty `middleware` array as a valid empty configuration, preventing a downstream validation failure.

Both changes ensure that a domain with no middleware rules is handled gracefully rather than producing a missing-config warning.
