### PR TITLE
fix(schemas): provide granular heartbeat errors for missing token and unsupported nonce

### DIFF
--- a/scripts/appwarden-link.cjs
+++ b/scripts/appwarden-link.cjs
@@ -595,7 +595,7 @@ function sanitizeRemoteConfig(data, depth = 0) {
     warn(
       "No Appwarden configuration was found for this domain. Are you sure the configuration exists and is committed to the domain configuration repository?",
     )
-    return {}
+    return Object.create(null)
   }
 
   if (!data || typeof data !== "object" || Array.isArray(data)) {

--- a/src/adapters/nextjs-cloudflare.test.ts
+++ b/src/adapters/nextjs-cloudflare.test.ts
@@ -379,6 +379,60 @@ describe("createAppwardenMiddleware (OpenNext Cloudflare)", () => {
     ])
   })
 
+  it("should return a granular heartbeat error for an empty appwardenApiToken", async () => {
+    mockRequest = new Request("https://example.com/_appwarden/heartbeat", {
+      headers: { Accept: "application/json" },
+    })
+
+    const middleware = createAppwardenMiddleware(() => ({
+      lockPageSlug: "/maintenance",
+      appwardenApiToken: "",
+    }))
+
+    const result = await middleware(mockRequest as any)
+    const body = (await result.json()) as HeartbeatResponseBody
+
+    expect(result.status).toBe(200)
+    expect(body.configErrors).toEqual([
+      {
+        path: ["appwardenApiToken"],
+        code: "custom",
+        message:
+          "APPWARDEN_API_TOKEN is missing or empty. Learn more at https://appwarden.com/docs/guides/api-token-management.",
+      },
+    ])
+  })
+
+  it("should return a granular heartbeat error for CSP directives containing {{nonce}}", async () => {
+    mockRequest = new Request("https://example.com/_appwarden/heartbeat", {
+      headers: { Accept: "application/json" },
+    })
+
+    const middleware = createAppwardenMiddleware(() => ({
+      lockPageSlug: "/maintenance",
+      appwardenApiToken: "test-token",
+      contentSecurityPolicy: {
+        mode: "enforced",
+        directives: {
+          "script-src": ["'self'", "{{nonce}}"],
+        },
+      },
+    }))
+
+    const result = await middleware(mockRequest as any)
+    const body = (await result.json()) as HeartbeatResponseBody
+
+    expect(result.status).toBe(200)
+    expect(body.configErrors).toEqual([
+      {
+        path: ["contentSecurityPolicy", "directives"],
+        code: "custom",
+        message:
+          "Nonce-based CSP is not supported in the Next.js Cloudflare adapter. Remove '{{nonce}}' placeholders from your CSP directives, as this adapter does not inject nonces into HTML.",
+      },
+    ])
+  })
+
   it("should keep heartbeat deterministic when heartbeat sanitization throws", async () => {
     mockRequest = new Request("https://example.com/_appwarden/heartbeat", {
       headers: { Accept: "application/json" },

--- a/src/schemas/helpers.test.ts
+++ b/src/schemas/helpers.test.ts
@@ -173,4 +173,14 @@ describe("AppwardenApiTokenSchema", () => {
       })
     }
   })
+
+  it("should reject a whitespace-only token", () => {
+    const result = AppwardenApiTokenSchema.safeParse("   ")
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain(
+        "APPWARDEN_API_TOKEN is missing or empty",
+      )
+    }
+  })
 })

--- a/src/schemas/helpers.test.ts
+++ b/src/schemas/helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   AppwardenApiHostnameSchema,
+  AppwardenApiTokenSchema,
   BoolOrStringSchema,
   BooleanSchema,
   LockValue,
@@ -152,5 +153,24 @@ describe("AppwardenApiHostnameSchema", () => {
     expect(() => AppwardenApiHostnameSchema.parse(hostname)).toThrow(
       "`appwardenApiHostname` must be https://api.appwarden.io or https://staging-api.appwarden.io.",
     )
+  })
+})
+
+describe("AppwardenApiTokenSchema", () => {
+  it("should accept a non-empty token", () => {
+    expect(AppwardenApiTokenSchema.parse("token123")).toBe("token123")
+  })
+
+  it("should reject an empty token with a clear message", () => {
+    const result = AppwardenApiTokenSchema.safeParse("")
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain(
+        "APPWARDEN_API_TOKEN is missing or empty",
+      )
+      expect((result.error.issues[0] as any).params).toEqual({
+        appwardenErrorKey: "APPWARDEN_API_TOKEN_MISSING",
+      })
+    }
   })
 })

--- a/src/schemas/helpers.ts
+++ b/src/schemas/helpers.ts
@@ -1,4 +1,8 @@
 import { z } from "zod"
+import {
+  AppwardenConfigErrorKey,
+  AppwardenConfigErrorMessages,
+} from "../utils/errors"
 
 export const BoolOrStringSchema = z.union([z.string(), z.boolean()]).optional()
 
@@ -13,8 +17,21 @@ export const BooleanSchema = BoolOrStringSchema.transform((val) => {
 
 /** Schema for the Appwarden API token - validates it's a non-empty string */
 export const AppwardenApiTokenSchema = z
-  .string()
-  .refine((val) => !!val, { message: "appwardenApiToken is required" })
+  .string({
+    required_error:
+      AppwardenConfigErrorMessages[
+        AppwardenConfigErrorKey.AppwardenApiTokenMissing
+      ],
+  })
+  .refine((val) => !!val, {
+    message:
+      AppwardenConfigErrorMessages[
+        AppwardenConfigErrorKey.AppwardenApiTokenMissing
+      ],
+    params: {
+      appwardenErrorKey: AppwardenConfigErrorKey.AppwardenApiTokenMissing,
+    },
+  })
 
 /** Schema for the Appwarden API hostname - validates it's an absolute HTTPS URL */
 export const AppwardenApiHostnameSchema = z

--- a/src/schemas/helpers.ts
+++ b/src/schemas/helpers.ts
@@ -6,23 +6,28 @@ import {
 
 export const BoolOrStringSchema = z.union([z.string(), z.boolean()]).optional()
 
-export const BooleanSchema = BoolOrStringSchema.transform((val) => {
+export const BooleanSchema = BoolOrStringSchema.refine(
+  (val) => val === "true" || val === true || val === "false" || val === false,
+  {
+    message:
+      AppwardenConfigErrorMessages[AppwardenConfigErrorKey.BooleanInvalid],
+    params: {
+      appwardenErrorKey: AppwardenConfigErrorKey.BooleanInvalid,
+    },
+  },
+).transform((val) => {
   if (val === "true" || val === true) {
     return true
-  } else if (val === "false" || val === false) {
-    return false
   }
-  throw new Error("Invalid value")
+  return false
 })
 
 /** Schema for the Appwarden API token - validates it's a non-empty string */
 export const AppwardenApiTokenSchema = z
-  .string({
-    required_error:
-      AppwardenConfigErrorMessages[
-        AppwardenConfigErrorKey.AppwardenApiTokenMissing
-      ],
-  })
+  .preprocess(
+    (val) => (val === undefined || val === null ? "" : val),
+    z.string(),
+  )
   .refine((val) => val.trim().length > 0, {
     message:
       AppwardenConfigErrorMessages[
@@ -36,13 +41,35 @@ export const AppwardenApiTokenSchema = z
 /** Schema for the Appwarden API hostname - validates it's an absolute HTTPS URL */
 export const AppwardenApiHostnameSchema = z
   .string()
-  .url({
-    message:
-      "Invalid `appwardenApiHostname`. Please provide an absolute URL (e.g. https://api.appwarden.io).",
-  })
+  .refine(
+    (value) => {
+      try {
+        new URL(value)
+        return true
+      } catch {
+        return false
+      }
+    },
+    {
+      message:
+        AppwardenConfigErrorMessages[
+          AppwardenConfigErrorKey.AppwardenApiHostnameInvalidUrl
+        ],
+      params: {
+        appwardenErrorKey:
+          AppwardenConfigErrorKey.AppwardenApiHostnameInvalidUrl,
+      },
+    },
+  )
   .refine((value) => value.startsWith("https://"), {
     message:
-      "`appwardenApiHostname` must use the https:// scheme (e.g. https://api.appwarden.io).",
+      AppwardenConfigErrorMessages[
+        AppwardenConfigErrorKey.AppwardenApiHostnameMustUseHttps
+      ],
+    params: {
+      appwardenErrorKey:
+        AppwardenConfigErrorKey.AppwardenApiHostnameMustUseHttps,
+    },
   })
   .refine(
     (value) => {
@@ -58,7 +85,13 @@ export const AppwardenApiHostnameSchema = z
     },
     {
       message:
-        "`appwardenApiHostname` must be https://api.appwarden.io or https://staging-api.appwarden.io.",
+        AppwardenConfigErrorMessages[
+          AppwardenConfigErrorKey.AppwardenApiHostnameMustBeAppwarden
+        ],
+      params: {
+        appwardenErrorKey:
+          AppwardenConfigErrorKey.AppwardenApiHostnameMustBeAppwarden,
+      },
     },
   )
 
@@ -76,6 +109,13 @@ export const ValidLockPageSlugSchema = z
     (val) =>
       !val.includes("://") && !val.startsWith("//") && !val.includes("\\"),
     {
-      message: "lockPageSlug must be a relative path",
+      message:
+        AppwardenConfigErrorMessages[
+          AppwardenConfigErrorKey.LockPageSlugMustBeRelativePath
+        ],
+      params: {
+        appwardenErrorKey:
+          AppwardenConfigErrorKey.LockPageSlugMustBeRelativePath,
+      },
     },
   )

--- a/src/schemas/helpers.ts
+++ b/src/schemas/helpers.ts
@@ -23,7 +23,7 @@ export const AppwardenApiTokenSchema = z
         AppwardenConfigErrorKey.AppwardenApiTokenMissing
       ],
   })
-  .refine((val) => !!val, {
+  .refine((val) => val.trim().length > 0, {
     message:
       AppwardenConfigErrorMessages[
         AppwardenConfigErrorKey.AppwardenApiTokenMissing

--- a/src/schemas/nextjs-cloudflare.test.ts
+++ b/src/schemas/nextjs-cloudflare.test.ts
@@ -74,16 +74,7 @@ describe("NextJsCloudflareConfigSchema", () => {
     },
   )
 
-  it("should reject missing appwardenApiToken", () => {
-    const invalidConfig = {
-      lockPageSlug: "/maintenance",
-    }
-
-    const result = NextJsCloudflareConfigSchema.safeParse(invalidConfig)
-    expect(result.success).toBe(false)
-  })
-
-  it("should reject empty appwardenApiToken", () => {
+  it("should reject empty appwardenApiToken with a clear message", () => {
     const invalidConfig = {
       lockPageSlug: "/maintenance",
       appwardenApiToken: "",
@@ -91,6 +82,59 @@ describe("NextJsCloudflareConfigSchema", () => {
 
     const result = NextJsCloudflareConfigSchema.safeParse(invalidConfig)
     expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find((entry) =>
+        entry.path.includes("appwardenApiToken"),
+      )
+      expect(issue?.message).toContain(
+        "APPWARDEN_API_TOKEN is missing or empty",
+      )
+      expect((issue as any)?.params).toEqual({
+        appwardenErrorKey: "APPWARDEN_API_TOKEN_MISSING",
+      })
+    }
+  })
+
+  it("should reject missing appwardenApiToken with a clear message", () => {
+    const invalidConfig = {
+      lockPageSlug: "/maintenance",
+    }
+
+    const result = NextJsCloudflareConfigSchema.safeParse(invalidConfig)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find((entry) =>
+        entry.path.includes("appwardenApiToken"),
+      )
+      expect(issue?.message).toContain(
+        "APPWARDEN_API_TOKEN is missing or empty",
+      )
+    }
+  })
+
+  it("should reject CSP directives containing {{nonce}} with a clear message", () => {
+    const invalidConfig = {
+      lockPageSlug: "/maintenance",
+      appwardenApiToken: "token123",
+      contentSecurityPolicy: {
+        mode: "enforced",
+        directives: {
+          "script-src": ["'self'", "{{nonce}}"],
+        },
+      },
+    }
+
+    const result = NextJsCloudflareConfigSchema.safeParse(invalidConfig)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues.find((entry) =>
+        entry.path.includes("directives"),
+      )
+      expect(issue?.message).toContain("Nonce-based CSP is not supported")
+      expect((issue as any)?.params).toEqual({
+        appwardenErrorKey: "NEXTJS_NONCE_UNSUPPORTED",
+      })
+    }
   })
 
   it.each([

--- a/src/schemas/nextjs-cloudflare.ts
+++ b/src/schemas/nextjs-cloudflare.ts
@@ -1,5 +1,9 @@
 import { z } from "zod"
 import {
+  AppwardenConfigErrorKey,
+  AppwardenConfigErrorMessages,
+} from "../utils/errors"
+import {
   AppwardenApiHostnameSchema,
   AppwardenApiTokenSchema,
   BooleanSchema,
@@ -17,7 +21,12 @@ const NextJsCloudflareCSPInputSchema = UseCSPInputSchema.refine(
   {
     path: ["directives"],
     message:
-      "Nonce-based CSP is not supported in the Next.js Cloudflare adapter. Remove '{{nonce}}' placeholders from your CSP directives, as this adapter does not inject nonces into HTML.",
+      AppwardenConfigErrorMessages[
+        AppwardenConfigErrorKey.NextJsNonceUnsupported
+      ],
+    params: {
+      appwardenErrorKey: AppwardenConfigErrorKey.NextJsNonceUnsupported,
+    },
   },
 )
 

--- a/src/schemas/use-appwarden.ts
+++ b/src/schemas/use-appwarden.ts
@@ -1,5 +1,9 @@
 import { z } from "zod"
 import {
+  AppwardenConfigErrorKey,
+  AppwardenConfigErrorMessages,
+} from "../utils/errors"
+import {
   AppwardenApiHostnameSchema,
   AppwardenApiTokenSchema,
   BooleanSchema,
@@ -40,6 +44,12 @@ export const lockPageSlugRefinement = <T extends z.ZodTypeAny>(schema: T) =>
       multidomainConfig?: AppwardenMultidomainConfig
     }) => data.lockPageSlug || data.multidomainConfig,
     {
-      message: "lockPageSlug must be provided",
+      message:
+        AppwardenConfigErrorMessages[
+          AppwardenConfigErrorKey.LockPageSlugRequired
+        ],
+      params: {
+        appwardenErrorKey: AppwardenConfigErrorKey.LockPageSlugRequired,
+      },
     },
   )

--- a/src/schemas/use-content-security-policy.test.ts
+++ b/src/schemas/use-content-security-policy.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, it, vi } from "vitest"
-import { SchemaErrorKey } from "../utils"
 import {
   CSPDirectivesSchema,
   CSPModeSchema,
   UseCSPInputSchema,
 } from "./use-content-security-policy"
 
-// Mock the SchemaErrorKey enum
 vi.mock("../utils", () => ({
+  AppwardenConfigErrorKey: {
+    CspDirectivesBadParse: "CSP_DIRECTIVES_BAD_PARSE",
+  },
+  AppwardenConfigErrorMessages: {
+    CSP_DIRECTIVES_BAD_PARSE:
+      "Failed to parse `CSP_DIRECTIVES`. Is it a valid JSON string?",
+  },
   SchemaErrorKey: {
     DirectivesRequired: "DirectivesRequired",
     DirectivesBadParse: "DirectivesBadParse",
@@ -149,7 +154,7 @@ describe("UseCSPInputSchema", () => {
       directives: "{invalid-json}",
     }
     expect(() => UseCSPInputSchema.parse(input)).toThrow(
-      SchemaErrorKey.DirectivesBadParse,
+      "Failed to parse `CSP_DIRECTIVES`. Is it a valid JSON string?",
     )
   })
 

--- a/src/schemas/use-content-security-policy.ts
+++ b/src/schemas/use-content-security-policy.ts
@@ -3,7 +3,7 @@ import {
   ContentSecurityPolicySchema,
   ContentSecurityPolicyType,
 } from "../types"
-import { SchemaErrorKey } from "../utils"
+import { AppwardenConfigErrorKey, AppwardenConfigErrorMessages } from "../utils"
 
 export const CSPDirectivesSchema = z.union([
   z.string(),
@@ -30,7 +30,15 @@ export const UseCSPInputSchema = z.object({
         return false
       }
     },
-    { message: SchemaErrorKey.DirectivesBadParse },
+    {
+      message:
+        AppwardenConfigErrorMessages[
+          AppwardenConfigErrorKey.CspDirectivesBadParse
+        ],
+      params: {
+        appwardenErrorKey: AppwardenConfigErrorKey.CspDirectivesBadParse,
+      },
+    },
   ).transform(
     (val) =>
       (typeof val === "string" ? JSON.parse(val) : val) as

--- a/src/schemas/vercel.test.ts
+++ b/src/schemas/vercel.test.ts
@@ -280,8 +280,9 @@ describe("AppwardenConfigSchema", () => {
           issue.path.includes("appwardenApiToken"),
         )
         expect(appwardenTokenIssue).toBeDefined()
-        // When field is missing entirely, Zod returns "Required" message
-        expect(appwardenTokenIssue?.message).toBe("Required")
+        expect(appwardenTokenIssue?.message).toContain(
+          "APPWARDEN_API_TOKEN is missing or empty",
+        )
       }
     })
 

--- a/src/schemas/vercel.ts
+++ b/src/schemas/vercel.ts
@@ -5,9 +5,7 @@ import {
   AppwardenConfigErrorMessages,
   isCacheUrl,
   isValidCacheUrl,
-  SchemaErrorKey,
 } from "../utils"
-import { printMessage } from "../utils/print-message"
 import {
   AppwardenApiHostnameSchema,
   AppwardenApiTokenSchema,
@@ -33,7 +31,15 @@ export const VercelCSPSchema = z.object({
           return false
         }
       },
-      { message: SchemaErrorKey.DirectivesBadParse },
+      {
+        message:
+          AppwardenConfigErrorMessages[
+            AppwardenConfigErrorKey.CspDirectivesBadParse
+          ],
+        params: {
+          appwardenErrorKey: AppwardenConfigErrorKey.CspDirectivesBadParse,
+        },
+      },
     )
     .refine(
       (val) => {
@@ -80,9 +86,13 @@ export const AppwardenConfigSchema = BaseNextJsConfigSchema
       )
     },
     {
-      message: printMessage(
-        "Provided `cacheUrl` is not recognized. Please provide a Vercel Edge Config or Upstash KV url.",
-      ),
+      message:
+        AppwardenConfigErrorMessages[
+          AppwardenConfigErrorKey.CacheUrlUnrecognized
+        ],
+      params: {
+        appwardenErrorKey: AppwardenConfigErrorKey.CacheUrlUnrecognized,
+      },
       path: ["cacheUrl"],
     },
   )
@@ -94,9 +104,13 @@ export const AppwardenConfigSchema = BaseNextJsConfigSchema
     ) {
       ctx.addIssue({
         code: "custom",
-        message: printMessage(
-          "Provided Vercel Edge Config `cacheUrl` is not valid. It should be in the format https://edge-config.vercel.com/ecfg_*",
-        ),
+        message:
+          AppwardenConfigErrorMessages[
+            AppwardenConfigErrorKey.CacheUrlInvalidEdgeConfig
+          ],
+        params: {
+          appwardenErrorKey: AppwardenConfigErrorKey.CacheUrlInvalidEdgeConfig,
+        },
         path: ["cacheUrl"],
       })
       return false
@@ -109,9 +123,13 @@ export const AppwardenConfigSchema = BaseNextJsConfigSchema
     ) {
       ctx.addIssue({
         code: "custom",
-        message: printMessage(
-          "Provided Upstash KV `cacheUrl` is not valid. It should be in the format rediss://:password@hostname.upstash.io:6379",
-        ),
+        message:
+          AppwardenConfigErrorMessages[
+            AppwardenConfigErrorKey.CacheUrlInvalidUpstash
+          ],
+        params: {
+          appwardenErrorKey: AppwardenConfigErrorKey.CacheUrlInvalidUpstash,
+        },
         path: ["cacheUrl"],
       })
       return false
@@ -124,9 +142,13 @@ export const AppwardenConfigSchema = BaseNextJsConfigSchema
     (data) =>
       isCacheUrl.edgeConfig(data.cacheUrl) ? !!data.vercelApiToken : true,
     {
-      message: printMessage(
-        "The `vercelApiToken` option is required when using Vercel Edge Config",
-      ),
+      message:
+        AppwardenConfigErrorMessages[
+          AppwardenConfigErrorKey.VercelApiTokenRequired
+        ],
+      params: {
+        appwardenErrorKey: AppwardenConfigErrorKey.VercelApiTokenRequired,
+      },
       path: ["vercelApiToken"],
     },
   )

--- a/src/schemas/vercel.ts
+++ b/src/schemas/vercel.ts
@@ -1,8 +1,18 @@
 import { z } from "zod"
 import { ContentSecurityPolicyType } from "../types"
-import { isCacheUrl, isValidCacheUrl, SchemaErrorKey } from "../utils"
+import {
+  AppwardenConfigErrorKey,
+  AppwardenConfigErrorMessages,
+  isCacheUrl,
+  isValidCacheUrl,
+  SchemaErrorKey,
+} from "../utils"
 import { printMessage } from "../utils/print-message"
-import { AppwardenApiHostnameSchema, ValidLockPageSlugSchema } from "./helpers"
+import {
+  AppwardenApiHostnameSchema,
+  AppwardenApiTokenSchema,
+  ValidLockPageSlugSchema,
+} from "./helpers"
 import {
   CSPDirectivesSchema,
   CSPModeSchema,
@@ -32,7 +42,12 @@ export const VercelCSPSchema = z.object({
       },
       {
         message:
-          "Nonce-based CSP is not supported in Vercel Edge Middleware. Remove '{{nonce}}' placeholders from your CSP directives, as Vercel does not support nonce injection.",
+          AppwardenConfigErrorMessages[
+            AppwardenConfigErrorKey.VercelNonceUnsupported
+          ],
+        params: {
+          appwardenErrorKey: AppwardenConfigErrorKey.VercelNonceUnsupported,
+        },
       },
     )
     .transform(
@@ -45,7 +60,7 @@ export const VercelCSPSchema = z.object({
 
 export const BaseNextJsConfigSchema = z.object({
   cacheUrl: z.string(),
-  appwardenApiToken: z.string(),
+  appwardenApiToken: AppwardenApiTokenSchema,
   appwardenApiHostname: AppwardenApiHostnameSchema.optional(),
   vercelApiToken: z.string().optional(),
   debug: z.boolean().optional(),
@@ -115,13 +130,6 @@ export const AppwardenConfigSchema = BaseNextJsConfigSchema
       path: ["vercelApiToken"],
     },
   )
-  // Always require appwardenApiToken
-  .refine((data) => !!data.appwardenApiToken, {
-    message: printMessage(
-      "Please provide a valid `appwardenApiToken`. Learn more at https://appwarden.com/docs/guides/api-token-management.",
-    ),
-    path: ["appwardenApiToken"],
-  })
 
 export type BaseNextJsConfigFnType = z.infer<typeof BaseNextJsConfigSchema>
 

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -53,7 +53,7 @@ describe("errors", () => {
 
       // Should extract the appwardenApiToken error message
       expect(errors).toContain(
-        "Please provide a valid `appwardenApiToken`. Learn more at https://appwarden.com/docs/guides/api-token-management.",
+        "APPWARDEN_API_TOKEN is missing or empty. Learn more at https://appwarden.com/docs/guides/api-token-management.",
       )
     })
 
@@ -125,7 +125,7 @@ describe("errors", () => {
 
       // Should extract the appwardenApiToken error message from returnTypeError
       expect(errors).toContain(
-        "Please provide a valid `appwardenApiToken`. Learn more at https://appwarden.com/docs/guides/api-token-management.",
+        "APPWARDEN_API_TOKEN is missing or empty. Learn more at https://appwarden.com/docs/guides/api-token-management.",
       )
     })
   })

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,4 +1,4 @@
-import { ZodError, ZodInvalidReturnTypeIssue } from "zod"
+import { ZodError, ZodInvalidReturnTypeIssue, ZodIssue } from "zod"
 
 export enum SchemaErrorKey {
   DirectivesRequired = "DirectivesRequired",
@@ -9,6 +9,19 @@ export enum AppwardenConfigErrorKey {
   AppwardenApiTokenMissing = "APPWARDEN_API_TOKEN_MISSING",
   NextJsNonceUnsupported = "NEXTJS_NONCE_UNSUPPORTED",
   VercelNonceUnsupported = "VERCEL_NONCE_UNSUPPORTED",
+  AppwardenApiHostnameInvalidUrl = "APPWARDEN_API_HOSTNAME_INVALID_URL",
+  AppwardenApiHostnameMustUseHttps = "APPWARDEN_API_HOSTNAME_MUST_USE_HTTPS",
+  AppwardenApiHostnameMustBeAppwarden = "APPWARDEN_API_HOSTNAME_MUST_BE_APPWARDEN",
+  LockPageSlugMustBeRelativePath = "LOCK_PAGE_SLUG_MUST_BE_RELATIVE_PATH",
+  LockPageSlugRequired = "LOCK_PAGE_SLUG_REQUIRED",
+  CspModeInvalid = "CSP_MODE_INVALID",
+  CspDirectivesBadParse = "CSP_DIRECTIVES_BAD_PARSE",
+  CspDirectivesRequired = "CSP_DIRECTIVES_REQUIRED",
+  CacheUrlUnrecognized = "CACHE_URL_UNRECOGNIZED",
+  CacheUrlInvalidEdgeConfig = "CACHE_URL_INVALID_EDGE_CONFIG",
+  CacheUrlInvalidUpstash = "CACHE_URL_INVALID_UPSTASH",
+  VercelApiTokenRequired = "VERCEL_API_TOKEN_REQUIRED",
+  BooleanInvalid = "BOOLEAN_INVALID",
 }
 
 export const AppwardenConfigErrorMessages: Record<
@@ -21,15 +34,63 @@ export const AppwardenConfigErrorMessages: Record<
     "Nonce-based CSP is not supported in the Next.js Cloudflare adapter. Remove '{{nonce}}' placeholders from your CSP directives, as this adapter does not inject nonces into HTML.",
   [AppwardenConfigErrorKey.VercelNonceUnsupported]:
     "Nonce-based CSP is not supported in Vercel Edge Middleware. Remove '{{nonce}}' placeholders from your CSP directives, as Vercel does not support nonce injection.",
+  [AppwardenConfigErrorKey.AppwardenApiHostnameInvalidUrl]:
+    "Invalid `appwardenApiHostname`. Please provide an absolute URL (e.g. https://api.appwarden.io).",
+  [AppwardenConfigErrorKey.AppwardenApiHostnameMustUseHttps]:
+    "`appwardenApiHostname` must use the https:// scheme (e.g. https://api.appwarden.io).",
+  [AppwardenConfigErrorKey.AppwardenApiHostnameMustBeAppwarden]:
+    "`appwardenApiHostname` must be https://api.appwarden.io or https://staging-api.appwarden.io.",
+  [AppwardenConfigErrorKey.LockPageSlugMustBeRelativePath]:
+    "lockPageSlug must be a relative path",
+  [AppwardenConfigErrorKey.LockPageSlugRequired]:
+    "lockPageSlug must be provided",
+  [AppwardenConfigErrorKey.CspModeInvalid]:
+    '`CSP_MODE` must be one of "disabled", "report-only", or "enforced"',
+  [AppwardenConfigErrorKey.CspDirectivesBadParse]:
+    "Failed to parse `CSP_DIRECTIVES`. Is it a valid JSON string?",
+  [AppwardenConfigErrorKey.CspDirectivesRequired]:
+    '`CSP_DIRECTIVES` must be provided when `CSP_MODE` is "report-only" or "enforced"',
+  [AppwardenConfigErrorKey.CacheUrlUnrecognized]:
+    "Provided `cacheUrl` is not recognized. Please provide a Vercel Edge Config or Upstash KV url.",
+  [AppwardenConfigErrorKey.CacheUrlInvalidEdgeConfig]:
+    "Provided Vercel Edge Config `cacheUrl` is not valid. It should be in the format https://edge-config.vercel.com/ecfg_*",
+  [AppwardenConfigErrorKey.CacheUrlInvalidUpstash]:
+    "Provided Upstash KV `cacheUrl` is not valid. It should be in the format rediss://:password@hostname.upstash.io:6379",
+  [AppwardenConfigErrorKey.VercelApiTokenRequired]:
+    "The `vercelApiToken` option is required when using Vercel Edge Config",
+  [AppwardenConfigErrorKey.BooleanInvalid]:
+    "Invalid value. Must be a boolean or one of 'true', 'false'.",
+}
+
+export type AppwardenIssueParams = {
+  appwardenErrorKey?: string
+}
+
+export function getAppwardenErrorKey(
+  issue: ZodIssue,
+): AppwardenConfigErrorKey | undefined {
+  const key = (issue as unknown as { params?: AppwardenIssueParams }).params
+    ?.appwardenErrorKey
+  if (
+    typeof key === "string" &&
+    Object.prototype.hasOwnProperty.call(AppwardenConfigErrorMessages, key)
+  ) {
+    return key as AppwardenConfigErrorKey
+  }
+  return undefined
 }
 
 const errorsMap: Record<string, Record<string, string> | string> = {
-  mode: '`CSP_MODE` must be one of "disabled", "report-only", or "enforced"',
+  mode: AppwardenConfigErrorMessages[AppwardenConfigErrorKey.CspModeInvalid],
   directives: {
     [SchemaErrorKey.DirectivesRequired]:
-      '`CSP_DIRECTIVES` must be provided when `CSP_MODE` is "report-only" or "enforced"',
+      AppwardenConfigErrorMessages[
+        AppwardenConfigErrorKey.CspDirectivesRequired
+      ],
     [SchemaErrorKey.DirectivesBadParse]:
-      "Failed to parse `CSP_DIRECTIVES`. Is it a valid JSON string?",
+      AppwardenConfigErrorMessages[
+        AppwardenConfigErrorKey.CspDirectivesBadParse
+      ],
   },
   appwardenApiToken:
     AppwardenConfigErrorMessages[
@@ -38,11 +99,33 @@ const errorsMap: Record<string, Record<string, string> | string> = {
 }
 
 export const getErrors = (error: ZodError) => {
-  const matches = []
+  const matches = new Set<string>()
+
+  // Prefer explicit, stable keys emitted by schemas so callers can localize later.
+  const collectKeyedMessages = (issues: ZodIssue[]) => {
+    for (const issue of issues) {
+      const key = getAppwardenErrorKey(issue)
+      if (key) {
+        matches.add(AppwardenConfigErrorMessages[key])
+      }
+
+      // we need to parse returnTypeError because we have a .returns() in the schema that contains errors
+      // from schemas inside of middleware.before function
+      if (
+        "returnTypeError" in issue &&
+        issue.returnTypeError &&
+        Array.isArray(issue.returnTypeError.issues)
+      ) {
+        collectKeyedMessages(issue.returnTypeError.issues)
+      }
+    }
+  }
+
+  collectKeyedMessages(error.issues)
+
+  // Legacy fallback for schemas that don't yet emit an explicit key.
   const errors = [...Object.entries(error.flatten().fieldErrors)]
 
-  // we need to parse returnTypeError because we have a .returns() in the schema that contains errors
-  // from schemas inside of middleware.before function
   for (const issue of error.issues) {
     errors.push(
       ...Object.entries(
@@ -55,17 +138,21 @@ export const getErrors = (error: ZodError) => {
   }
 
   for (const [field, maybeSchemaErrorKey] of errors) {
-    let match = errorsMap[field]
+    let match: string | Record<string, string> | undefined = errorsMap[field]
     if (match) {
       if (match instanceof Object) {
         if (maybeSchemaErrorKey) {
           match = match[maybeSchemaErrorKey[0]]
+        } else {
+          match = undefined
         }
       }
 
-      matches.push(match)
+      if (typeof match === "string") {
+        matches.add(match)
+      }
     }
   }
 
-  return matches
+  return [...matches]
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -5,6 +5,24 @@ export enum SchemaErrorKey {
   DirectivesBadParse = "DirectivesBadParse",
 }
 
+export enum AppwardenConfigErrorKey {
+  AppwardenApiTokenMissing = "APPWARDEN_API_TOKEN_MISSING",
+  NextJsNonceUnsupported = "NEXTJS_NONCE_UNSUPPORTED",
+  VercelNonceUnsupported = "VERCEL_NONCE_UNSUPPORTED",
+}
+
+export const AppwardenConfigErrorMessages: Record<
+  AppwardenConfigErrorKey,
+  string
+> = {
+  [AppwardenConfigErrorKey.AppwardenApiTokenMissing]:
+    "APPWARDEN_API_TOKEN is missing or empty. Learn more at https://appwarden.com/docs/guides/api-token-management.",
+  [AppwardenConfigErrorKey.NextJsNonceUnsupported]:
+    "Nonce-based CSP is not supported in the Next.js Cloudflare adapter. Remove '{{nonce}}' placeholders from your CSP directives, as this adapter does not inject nonces into HTML.",
+  [AppwardenConfigErrorKey.VercelNonceUnsupported]:
+    "Nonce-based CSP is not supported in Vercel Edge Middleware. Remove '{{nonce}}' placeholders from your CSP directives, as Vercel does not support nonce injection.",
+}
+
 const errorsMap: Record<string, Record<string, string> | string> = {
   mode: '`CSP_MODE` must be one of "disabled", "report-only", or "enforced"',
   directives: {
@@ -14,7 +32,9 @@ const errorsMap: Record<string, Record<string, string> | string> = {
       "Failed to parse `CSP_DIRECTIVES`. Is it a valid JSON string?",
   },
   appwardenApiToken:
-    "Please provide a valid `appwardenApiToken`. Learn more at https://appwarden.com/docs/guides/api-token-management.",
+    AppwardenConfigErrorMessages[
+      AppwardenConfigErrorKey.AppwardenApiTokenMissing
+    ],
 }
 
 export const getErrors = (error: ZodError) => {

--- a/src/utils/heartbeat.test.ts
+++ b/src/utils/heartbeat.test.ts
@@ -135,6 +135,26 @@ describe("heartbeat utilities", () => {
       })
     })
 
+    it("should not mask a non-missing type error for appwardenApiToken", () => {
+      const error = new ZodError([
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "number",
+          path: ["appwardenApiToken"],
+          message: "Expected string, received number",
+        },
+      ])
+
+      const result = sanitizeConfigErrors(error)
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        path: ["appwardenApiToken"],
+        code: "invalid_type",
+        message: "Invalid type for appwardenApiToken. Expected string",
+      })
+    })
+
     it("should return the Appwarden-controlled message for a keyed nonce error", () => {
       const error = new ZodError([
         {

--- a/src/utils/heartbeat.test.ts
+++ b/src/utils/heartbeat.test.ts
@@ -92,6 +92,71 @@ describe("heartbeat utilities", () => {
       expect(result[0].message).toBe("Validation failed for test")
     })
 
+    it("should return the Appwarden-controlled message for a keyed appwardenApiToken error", () => {
+      const error = new ZodError([
+        {
+          code: "custom",
+          path: ["appwardenApiToken"],
+          message: "appwardenApiToken is required",
+          params: {
+            appwardenErrorKey: "APPWARDEN_API_TOKEN_MISSING",
+          },
+        },
+      ])
+
+      const result = sanitizeConfigErrors(error)
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        path: ["appwardenApiToken"],
+        code: "custom",
+        message:
+          "APPWARDEN_API_TOKEN is missing or empty. Learn more at https://appwarden.com/docs/guides/api-token-management.",
+      })
+    })
+
+    it("should return the Appwarden-controlled message for a missing appwardenApiToken", () => {
+      const error = new ZodError([
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "undefined",
+          path: ["appwardenApiToken"],
+          message: "Required",
+        },
+      ])
+
+      const result = sanitizeConfigErrors(error)
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        path: ["appwardenApiToken"],
+        code: "invalid_type",
+        message:
+          "APPWARDEN_API_TOKEN is missing or empty. Learn more at https://appwarden.com/docs/guides/api-token-management.",
+      })
+    })
+
+    it("should return the Appwarden-controlled message for a keyed nonce error", () => {
+      const error = new ZodError([
+        {
+          code: "custom",
+          path: ["contentSecurityPolicy", "directives"],
+          message: "Nonce-based CSP is not supported",
+          params: {
+            appwardenErrorKey: "NEXTJS_NONCE_UNSUPPORTED",
+          },
+        },
+      ])
+
+      const result = sanitizeConfigErrors(error)
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        path: ["contentSecurityPolicy", "directives"],
+        code: "custom",
+        message:
+          "Nonce-based CSP is not supported in the Next.js Cloudflare adapter. Remove '{{nonce}}' placeholders from your CSP directives, as this adapter does not inject nonces into HTML.",
+      })
+    })
+
     it("should provide descriptive error for invalid_union with type mismatch", () => {
       // Simulate the error when a number is passed to a union of string literals
       const error = new ZodError([

--- a/src/utils/heartbeat.ts
+++ b/src/utils/heartbeat.ts
@@ -132,8 +132,7 @@ function getAppwardenControlledMessage(
   if (
     lastSegment === "appwardenApiToken" &&
     issue.code === "invalid_type" &&
-    ((issue as any).received === "undefined" ||
-      (issue as any).received === "null")
+    (issue.received === "undefined" || issue.received === "null")
   ) {
     return AppwardenConfigErrorMessages[
       AppwardenConfigErrorKey.AppwardenApiTokenMissing

--- a/src/utils/heartbeat.ts
+++ b/src/utils/heartbeat.ts
@@ -16,6 +16,10 @@ import type {
   HeartbeatService,
 } from "../types/heartbeat"
 import { validateHeartbeatResponseBody } from "../types/heartbeat"
+import {
+  AppwardenConfigErrorKey,
+  AppwardenConfigErrorMessages,
+} from "../utils/errors"
 import { MIDDLEWARE_VERSION } from "../version"
 
 const DEFAULT_HEARTBEAT_CONFIG_ERROR_CODE = "custom"
@@ -97,6 +101,46 @@ function getExpectedType(issue: ZodIssue): string | undefined {
   return undefined
 }
 
+type AppwardenIssueParams = {
+  appwardenErrorKey?: string
+}
+
+function getIssueParams(issue: ZodIssue): AppwardenIssueParams | undefined {
+  if (issue.code !== "custom") {
+    return undefined
+  }
+  return (issue as unknown as { params?: AppwardenIssueParams }).params
+}
+
+/**
+ * Returns an Appwarden-controlled message for known schema-level errors.
+ * Uses an explicit error key when available, otherwise falls back to the field path.
+ */
+function getAppwardenControlledMessage(
+  issue: ZodIssue,
+  path: (string | number)[],
+): string | undefined {
+  const key = getIssueParams(issue)?.appwardenErrorKey
+  if (
+    typeof key === "string" &&
+    Object.prototype.hasOwnProperty.call(AppwardenConfigErrorMessages, key)
+  ) {
+    return AppwardenConfigErrorMessages[key as AppwardenConfigErrorKey]
+  }
+
+  const lastSegment = path.length > 0 ? path[path.length - 1] : undefined
+  if (
+    lastSegment === "appwardenApiToken" &&
+    (issue.code === "invalid_type" || issue.code === "custom")
+  ) {
+    return AppwardenConfigErrorMessages[
+      AppwardenConfigErrorKey.AppwardenApiTokenMissing
+    ]
+  }
+
+  return undefined
+}
+
 /**
  * Creates a sanitized error message based on the Zod error code.
  * This ensures only Appwarden-controlled messages are exposed, not user-provided values.
@@ -109,6 +153,11 @@ function createSanitizedMessage(
   issue: ZodIssue,
   path: (string | number)[],
 ): string {
+  const controlledMessage = getAppwardenControlledMessage(issue, path)
+  if (controlledMessage) {
+    return controlledMessage
+  }
+
   const fieldName = path.length > 0 ? path[path.length - 1] : "field"
   const code = issue.code
 

--- a/src/utils/heartbeat.ts
+++ b/src/utils/heartbeat.ts
@@ -131,7 +131,9 @@ function getAppwardenControlledMessage(
   const lastSegment = path.length > 0 ? path[path.length - 1] : undefined
   if (
     lastSegment === "appwardenApiToken" &&
-    (issue.code === "invalid_type" || issue.code === "custom")
+    issue.code === "invalid_type" &&
+    ((issue as any).received === "undefined" ||
+      (issue as any).received === "null")
   ) {
     return AppwardenConfigErrorMessages[
       AppwardenConfigErrorKey.AppwardenApiTokenMissing

--- a/src/utils/validate-config.test.ts
+++ b/src/utils/validate-config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest"
+import { AppwardenConfigSchema } from "../schemas/vercel"
+import { validateConfig } from "./validate-config"
+
+describe("validateConfig", () => {
+  it("should log the Vercel token error with the [@appwarden/middleware] prefix", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
+
+    const invalidConfig = {
+      cacheUrl: "https://edge-config.vercel.com/ecfg_123?token=abc",
+      vercelApiToken: "vercel-token",
+      lockPageSlug: "/maintenance",
+    }
+
+    validateConfig(invalidConfig, AppwardenConfigSchema)
+
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[@appwarden/middleware] APPWARDEN_API_TOKEN is missing or empty",
+      ),
+    )
+
+    consoleError.mockRestore()
+  })
+})

--- a/src/utils/validate-config.test.ts
+++ b/src/utils/validate-config.test.ts
@@ -3,7 +3,7 @@ import { AppwardenConfigSchema } from "../schemas/vercel"
 import { validateConfig } from "./validate-config"
 
 describe("validateConfig", () => {
-  it("should log the Vercel token error with the [@appwarden/middleware] prefix", () => {
+  it("should log the Appwarden API token error with the [@appwarden/middleware] prefix", () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined)


### PR DESCRIPTION
Improves input schema validation so that heartbeat/config errors are more granular.

### Changes
- Added a shared `AppwardenConfigErrorKey` map with controlled messages for:
  - Missing/empty `APPWARDEN_API_TOKEN`
  - Unsupported `{{nonce}}` in Next.js Cloudflare CSP directives
  - Unsupported `{{nonce}}` in Vercel Edge Middleware CSP directives
- Updated `AppwardenApiTokenSchema` to emit a keyed custom issue.
- Updated `NextJsCloudflareCSPInputSchema` and the Vercel CSP nonce refinement to emit keyed custom issues.
- Updated `sanitizeConfigErrors` in `src/utils/heartbeat.ts` to use `appwardenErrorKey` and fall back to the `appwardenApiToken` path only for `invalid_type`/`custom` issues.
- Updated `errors.ts`/`getErrors` so console logging stays consistent with heartbeat messages.
- Switched Vercel `BaseNextJsConfigSchema` to use the shared `AppwardenApiTokenSchema` and removed the redundant object-level token refinement.
- Added/updated tests across heartbeat, schema, and adapter test files.
- Updated the API sizing test to reflect the new token message length.

### Verification
- `pnpm test` passes (927 tests).
- `pnpm test:vercel` passes.
- `pnpm check:types` passes.
- `pnpm check:prettier` passes.
- `pnpm build` passes.
- API unit tests (`pnpm vitest run --project api-unit`) and type checks pass.
