### PR TITLE
fix: return sanitized validation errors when Cloudflare adapter config evaluation throws ZodError

### DIFF
--- a/src/adapters/astro-cloudflare.test.ts
+++ b/src/adapters/astro-cloudflare.test.ts
@@ -1,6 +1,7 @@
 import type { APIContext } from "astro"
 import { waitUntil } from "cloudflare:workers"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ZodError } from "zod"
 import { checkLockStatus } from "../core"
 import type { HeartbeatResponseBody } from "../types"
 import * as utils from "../utils"
@@ -332,6 +333,41 @@ describe("createAppwardenMiddleware (Astro)", () => {
         path: ["config"],
         code: "custom",
         message: "Appwarden config evaluation failed",
+      },
+    ])
+    expect(mockNext).not.toHaveBeenCalled()
+  })
+
+  it("should return sanitized heartbeat config errors when config evaluation throws a ZodError", async () => {
+    mockContext.request = new Request(
+      "https://example.com/_appwarden/heartbeat",
+      { headers: { Accept: "application/json" } },
+    )
+
+    const middleware = createAppwardenMiddleware(() => {
+      throw new ZodError([
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "undefined",
+          path: ["appwardenApiToken"],
+          message: "Required",
+        },
+      ])
+    })
+
+    const result = asResponse(
+      await middleware(asAPIContext(mockContext), mockNext),
+    )
+    const body = (await result.json()) as HeartbeatResponseBody
+
+    expect(result.status).toBe(200)
+    expect(body.configErrors).toEqual([
+      {
+        path: ["appwardenApiToken"],
+        code: "invalid_type",
+        message:
+          "APPWARDEN_API_TOKEN is missing or empty. Learn more at https://appwarden.com/docs/guides/api-token-management.",
       },
     ])
     expect(mockNext).not.toHaveBeenCalled()

--- a/src/adapters/astro-cloudflare.ts
+++ b/src/adapters/astro-cloudflare.ts
@@ -1,5 +1,6 @@
 import type { APIContext } from "astro"
 import { env as cloudflareEnv, waitUntil } from "cloudflare:workers"
+import { ZodError } from "zod"
 import { HEARTBEAT_SERVICES } from "../constants"
 import { checkLockStatus } from "../core"
 import type {
@@ -73,17 +74,19 @@ const createAstroHeartbeatResponse = (
         ? []
         : sanitizeConfigErrors(validationResult.error),
     )
-  } catch {
+  } catch (error) {
     return handleHeartbeatRequest(
       request,
       HEARTBEAT_SERVICES.CLOUDFLARE_ASTRO,
-      [
-        createHeartbeatConfigError(
-          ["config"],
-          "custom",
-          "Appwarden config evaluation failed",
-        ),
-      ],
+      error instanceof ZodError
+        ? sanitizeConfigErrors(error)
+        : [
+            createHeartbeatConfigError(
+              ["config"],
+              "custom",
+              "Appwarden config evaluation failed",
+            ),
+          ],
     )
   }
 }

--- a/src/adapters/nextjs-cloudflare.test.ts
+++ b/src/adapters/nextjs-cloudflare.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ZodError } from "zod"
 import { checkLockStatus } from "../core"
 import type { HeartbeatResponseBody } from "../types"
 import * as utils from "../utils"
@@ -375,6 +376,37 @@ describe("createAppwardenMiddleware (OpenNext Cloudflare)", () => {
         path: ["config"],
         code: "custom",
         message: "Appwarden config evaluation failed",
+      },
+    ])
+  })
+
+  it("should return sanitized heartbeat config errors when config evaluation throws a ZodError", async () => {
+    mockRequest = new Request("https://example.com/_appwarden/heartbeat", {
+      headers: { Accept: "application/json" },
+    })
+
+    const middleware = createAppwardenMiddleware(() => {
+      throw new ZodError([
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "undefined",
+          path: ["appwardenApiToken"],
+          message: "Required",
+        },
+      ])
+    })
+
+    const result = await middleware(mockRequest as any)
+    const body = (await result.json()) as HeartbeatResponseBody
+
+    expect(result.status).toBe(200)
+    expect(body.configErrors).toEqual([
+      {
+        path: ["appwardenApiToken"],
+        code: "invalid_type",
+        message:
+          "APPWARDEN_API_TOKEN is missing or empty. Learn more at https://appwarden.com/docs/guides/api-token-management.",
       },
     ])
   })

--- a/src/adapters/nextjs-cloudflare.ts
+++ b/src/adapters/nextjs-cloudflare.ts
@@ -4,6 +4,7 @@ import {
   type NextFetchEvent,
   type NextRequest,
 } from "next/server"
+import { ZodError } from "zod"
 import { HEARTBEAT_SERVICES } from "../constants"
 import { checkLockStatus } from "../core"
 import type {
@@ -82,15 +83,21 @@ const createNextJsHeartbeatResponse = (
           : sanitizeConfigErrors(validationResult.error),
       ),
     )
-  } catch {
+  } catch (error) {
     return toNextResponse(
-      handleHeartbeatRequest(request, HEARTBEAT_SERVICES.CLOUDFLARE_NEXTJS, [
-        createHeartbeatConfigError(
-          ["config"],
-          "custom",
-          "Appwarden config evaluation failed",
-        ),
-      ]),
+      handleHeartbeatRequest(
+        request,
+        HEARTBEAT_SERVICES.CLOUDFLARE_NEXTJS,
+        error instanceof ZodError
+          ? sanitizeConfigErrors(error)
+          : [
+              createHeartbeatConfigError(
+                ["config"],
+                "custom",
+                "Appwarden config evaluation failed",
+              ),
+            ],
+      ),
     )
   }
 }

--- a/src/adapters/react-router-cloudflare.test.ts
+++ b/src/adapters/react-router-cloudflare.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ZodError } from "zod"
 import { checkLockStatus } from "../core"
 import type { HeartbeatResponseBody } from "../types"
 import * as utils from "../utils"
@@ -239,6 +240,42 @@ describe("createAppwardenMiddleware", () => {
         path: ["config"],
         code: "custom",
         message: "Appwarden config evaluation failed",
+      },
+    ])
+    expect(mockNext).not.toHaveBeenCalled()
+    expect(checkLockStatus).not.toHaveBeenCalled()
+  })
+
+  it("should return sanitized heartbeat config errors when config evaluation throws a ZodError", async () => {
+    mockArgs.request = new Request("https://example.com/_appwarden/heartbeat", {
+      headers: { Accept: "application/json" },
+    })
+
+    const middleware = createAppwardenMiddleware(() => {
+      throw new ZodError([
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "undefined",
+          path: ["appwardenApiToken"],
+          message: "Required",
+        },
+      ])
+    })
+
+    const result = await middleware(mockArgs, mockNext)
+    expect(result).toBeInstanceOf(Response)
+
+    const response = result as Response
+    const body = (await response.json()) as HeartbeatResponseBody
+
+    expect(response.status).toBe(200)
+    expect(body.configErrors).toEqual([
+      {
+        path: ["appwardenApiToken"],
+        code: "invalid_type",
+        message:
+          "APPWARDEN_API_TOKEN is missing or empty. Learn more at https://appwarden.com/docs/guides/api-token-management.",
       },
     ])
     expect(mockNext).not.toHaveBeenCalled()

--- a/src/adapters/react-router-cloudflare.ts
+++ b/src/adapters/react-router-cloudflare.ts
@@ -1,4 +1,5 @@
 import { waitUntil } from "cloudflare:workers"
+import { ZodError } from "zod"
 import { HEARTBEAT_SERVICES } from "../constants"
 import { checkLockStatus } from "../core"
 import type { ReactRouterCloudflareConfig } from "../schemas/react-router-cloudflare"
@@ -36,17 +37,18 @@ export function getAppwardenConfiguration(
 
 const createConfigEvaluationHeartbeatResponse = (
   request: Request,
+  configErrors = [
+    createHeartbeatConfigError(
+      ["config"],
+      "custom",
+      "Appwarden config evaluation failed",
+    ),
+  ],
 ): Response => {
   return handleHeartbeatRequest(
     request,
     HEARTBEAT_SERVICES.CLOUDFLARE_REACT_ROUTER,
-    [
-      createHeartbeatConfigError(
-        ["config"],
-        "custom",
-        "Appwarden config evaluation failed",
-      ),
-    ],
+    configErrors,
   )
 }
 
@@ -65,8 +67,11 @@ const handleReactRouterHeartbeatRequest = (
         ? []
         : sanitizeConfigErrors(validationResult.error),
     )
-  } catch {
-    return createConfigEvaluationHeartbeatResponse(request)
+  } catch (error) {
+    return createConfigEvaluationHeartbeatResponse(
+      request,
+      error instanceof ZodError ? sanitizeConfigErrors(error) : undefined,
+    )
   }
 }
 

--- a/src/adapters/tanstack-start-cloudflare.test.ts
+++ b/src/adapters/tanstack-start-cloudflare.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ZodError } from "zod"
 import { checkLockStatus } from "../core"
 import type { HeartbeatResponseBody } from "../types"
 import * as utils from "../utils"
@@ -221,6 +222,39 @@ describe("createAppwardenMiddleware (TanStack Start)", () => {
         path: ["config"],
         code: "custom",
         message: "Appwarden config evaluation failed",
+      },
+    ])
+    expect(mockNext).not.toHaveBeenCalled()
+    expect(checkLockStatus).not.toHaveBeenCalled()
+  })
+
+  it("should throw sanitized heartbeat config errors when config evaluation throws a ZodError", async () => {
+    mockArgs.request = new Request("https://example.com/_appwarden/heartbeat", {
+      headers: { Accept: "application/json" },
+    })
+
+    const middleware = createAppwardenMiddleware(() => {
+      throw new ZodError([
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "undefined",
+          path: ["appwardenApiToken"],
+          message: "Required",
+        },
+      ])
+    })
+
+    const response = await getThrownResponse(middleware(mockArgs))
+    const body = (await response.json()) as HeartbeatResponseBody
+
+    expect(response.status).toBe(200)
+    expect(body.configErrors).toEqual([
+      {
+        path: ["appwardenApiToken"],
+        code: "invalid_type",
+        message:
+          "APPWARDEN_API_TOKEN is missing or empty. Learn more at https://appwarden.com/docs/guides/api-token-management.",
       },
     ])
     expect(mockNext).not.toHaveBeenCalled()

--- a/src/adapters/tanstack-start-cloudflare.ts
+++ b/src/adapters/tanstack-start-cloudflare.ts
@@ -1,4 +1,5 @@
 import { waitUntil } from "cloudflare:workers"
+import { ZodError } from "zod"
 import { HEARTBEAT_SERVICES } from "../constants"
 import { checkLockStatus } from "../core"
 import type {
@@ -49,17 +50,19 @@ const createTanStackHeartbeatResponse = (
         ? []
         : sanitizeConfigErrors(validationResult.error),
     )
-  } catch {
+  } catch (error) {
     return handleHeartbeatRequest(
       request,
       HEARTBEAT_SERVICES.CLOUDFLARE_TANSTACK_START,
-      [
-        createHeartbeatConfigError(
-          ["config"],
-          "custom",
-          "Appwarden config evaluation failed",
-        ),
-      ],
+      error instanceof ZodError
+        ? sanitizeConfigErrors(error)
+        : [
+            createHeartbeatConfigError(
+              ["config"],
+              "custom",
+              "Appwarden config evaluation failed",
+            ),
+          ],
     )
   }
 }


### PR DESCRIPTION
Uniform heartbeat error handling across all Cloudflare adapters.

When a config function throws a `ZodError`, the adapters now pass it through `sanitizeConfigErrors` instead of returning the generic "Appwarden config evaluation failed" message. Non-Zod exceptions still fall back to the generic message.

This matches the existing behavior of the Cloudflare runner (`src/runners/appwarden-on-cloudflare.ts`) and gives customers actionable validation errors on the heartbeat endpoint.

### Changed adapters
- `src/adapters/nextjs-cloudflare.ts`
- `src/adapters/astro-cloudflare.ts`
- `src/adapters/react-router-cloudflare.ts`
- `src/adapters/tanstack-start-cloudflare.ts`

### Tests
Added a new test case to each adapter's test file that verifies a thrown `ZodError` for a missing `appwardenApiToken` is sanitized to the controlled `APPWARDEN_API_TOKEN is missing or empty` message.

All 933 tests pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author