### PR TITLE
chore: manager agent

### DIFF
--- a/.github/manager-agent-prompt.md
+++ b/.github/manager-agent-prompt.md
@@ -1,0 +1,28 @@
+# Manager Agent Instructions
+
+You are the manager agent for this repository. Your job is to manage open pull requests according to the rules below. Use the GitHub API or the `gh` CLI with the token available in the environment.
+
+## Pre-step
+
+0. Read metadata for all open pull requests in this repository. If there are no open pull requests, exit immediatly.
+
+## Rules
+
+1. **Documentation PRs**: If an open PR has the `documentation` label and is mergeable (required checks passing, no conflicts, `mergeable` state is `true`), merge it. If it is not mergeable, leave it alone.
+
+2. **Release PRs**: If an open PR has `chore(release)` in its title and is mergeable, merge it. If it is not mergeable, leave it alone.
+
+3. **Dependabot batching**: If more than one open PR is from `dependabot[bot]` and no open PR has the exact title `chore(deps): batch update`, create a new PR that combines all of those dependabot PRs:
+   - Title: `chore(deps): batch update`
+   - Description: List every combined PR, its title, and the version update it introduces (extract the version bump from the PR title if present).
+   - Branch the new PR from the default branch and include the changes from each dependabot PR.
+
+4. **Batch update PR**: If an open PR has the exact title `chore(deps): batch update` and is mergeable, merge it. If it is not mergeable, leave it alone.
+
+## General guidelines
+
+- Only perform actions that are safe and verifiable.
+- If a merge is not possible, do not force it; report the reason and stop.
+- After any merge or PR creation, report the PR number and outcome.
+- Prefer the GitHub CLI (`gh`) when available; otherwise use the GitHub REST API.
+- Do not close, delete, or modify unrelated PRs.

--- a/.github/manager-agent-prompt.md
+++ b/.github/manager-agent-prompt.md
@@ -4,7 +4,7 @@ You are the manager agent for this repository. Your job is to manage open pull r
 
 ## Pre-step
 
-0. Read metadata for all open pull requests in this repository. If there are no open pull requests, exit immediatly.
+0. Read metadata for all open pull requests in this repository. If there are no open pull requests, exit immediately.
 
 ## Rules
 

--- a/.github/workflows/scheduled-copilot-agent.yml
+++ b/.github/workflows/scheduled-copilot-agent.yml
@@ -15,7 +15,7 @@ jobs:
   copilot-agent:
     name: Initialize Copilot agent
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/scheduled-copilot-agent.yml
+++ b/.github/workflows/scheduled-copilot-agent.yml
@@ -37,7 +37,7 @@ jobs:
         if: steps.check-prs.outputs.has_prs == 'true'
         uses: actions/setup-copilot@v0
 
-      - name: Initialize Copilot agent (haiku model, blank prompt)
+      - name: Initialize Copilot agent (haiku model)
         if: steps.check-prs.outputs.has_prs == 'true'
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scheduled-copilot-agent.yml
+++ b/.github/workflows/scheduled-copilot-agent.yml
@@ -1,0 +1,55 @@
+name: Manager Agent
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: manager-agent
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  copilot-agent:
+    name: Initialize Copilot agent
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Check for open pull requests
+        id: check-prs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          count=$(gh pr list --repo ${{ github.repository }} --state open --limit 1 --json number | jq 'length')
+          if [ "$count" -eq 0 ]; then
+            echo "No open pull requests. Skipping Copilot agent."
+            echo "has_prs=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_prs=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup GitHub Copilot CLI
+        if: steps.check-prs.outputs.has_prs == 'true'
+        uses: actions/setup-copilot@v0
+
+      - name: Initialize Copilot agent (haiku model, blank prompt)
+        if: steps.check-prs.outputs.has_prs == 'true'
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PROMPT=$(cat .github/manager-agent-prompt.md)
+          PROMPT="${PROMPT}
+
+          ## Final step
+          After completing all actions, output exactly one line starting with \`CAVEMAN_SUMMARY:\` followed by a brief caveman-style summary of what you did. Keep it to one short sentence. Example: \`CAVEMAN_SUMMARY: Agent merged 2 PRs. No dependabot batch needed.\`
+          "
+          copilot -p "$PROMPT" --model haiku --no-ask-user -s | tee /tmp/agent-output.log
+          SUMMARY=$(grep '^CAVEMAN_SUMMARY:' /tmp/agent-output.log | sed 's/^CAVEMAN_SUMMARY: *//' | head -n 1)
+          if [ -n "$SUMMARY" ]; then
+            echo "::notice title=Manager Agent Summary::$SUMMARY"
+          fi

--- a/.github/workflows/scheduled-copilot-agent.yml
+++ b/.github/workflows/scheduled-copilot-agent.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       - name: Check for open pull requests
         id: check-prs

--- a/.github/workflows/scheduled-copilot-agent.yml
+++ b/.github/workflows/scheduled-copilot-agent.yml
@@ -51,5 +51,6 @@ jobs:
           copilot -p "$PROMPT" --model haiku --no-ask-user -s | tee /tmp/agent-output.log
           SUMMARY=$(grep '^CAVEMAN_SUMMARY:' /tmp/agent-output.log | sed 's/^CAVEMAN_SUMMARY: *//' | head -n 1)
           if [ -n "$SUMMARY" ]; then
-            echo "::notice title=Manager Agent Summary::$SUMMARY"
+            SUMMARY_ESCAPED=$(printf '%s' "$SUMMARY" | sed -e 's/%/%25/g' -e 's/\r/%0D/g' -e 's/\n/%0A/g')
+            echo "::notice title=Manager Agent Summary::$SUMMARY_ESCAPED"
           fi

--- a/.github/workflows/scheduled-copilot-agent.yml
+++ b/.github/workflows/scheduled-copilot-agent.yml
@@ -49,6 +49,8 @@ jobs:
           After completing all actions, output exactly one line starting with \`CAVEMAN_SUMMARY:\` followed by a brief caveman-style summary of what you did. Keep it to one short sentence. Example: \`CAVEMAN_SUMMARY: Agent merged 2 PRs. No dependabot batch needed.\`
           "
           copilot -p "$PROMPT" --model haiku --no-ask-user -s | tee /tmp/agent-output.log
+          copilot_status=${PIPESTATUS[0]}
+          if [ "$copilot_status" -ne 0 ]; then exit "$copilot_status"; fi
           SUMMARY=$(grep '^CAVEMAN_SUMMARY:' /tmp/agent-output.log | sed 's/^CAVEMAN_SUMMARY: *//' | head -n 1)
           if [ -n "$SUMMARY" ]; then
             SUMMARY_ESCAPED=$(printf '%s' "$SUMMARY" | sed -e 's/%/%25/g' -e 's/\r/%0D/g' -e 's/\n/%0A/g')


### PR DESCRIPTION
Updates the manager agent workflow so the Copilot agent emits a brief caveman-style summary of actions taken, then extracts it and posts it as a GitHub annotation (`::notice`).

Also includes the `.github/manager-agent-prompt.md` that the workflow depends on.
