### PR TITLE
fix: install Copilot CLI via official script instead of missing setup-copilot action

### DIFF
--- a/.github/workflows/scheduled-copilot-agent.yml
+++ b/.github/workflows/scheduled-copilot-agent.yml
@@ -35,9 +35,9 @@ jobs:
 
       - name: Setup GitHub Copilot CLI
         if: steps.check-prs.outputs.has_prs == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: curl -fsSL https://gh.io/copilot-install | bash
+        run: |
+          curl --fail --silent --show-error --location https://gh.io/copilot-install -o /tmp/copilot-install.sh
+          bash /tmp/copilot-install.sh
 
       - name: Initialize Copilot agent (haiku model)
         if: steps.check-prs.outputs.has_prs == 'true'

--- a/.github/workflows/scheduled-copilot-agent.yml
+++ b/.github/workflows/scheduled-copilot-agent.yml
@@ -35,7 +35,9 @@ jobs:
 
       - name: Setup GitHub Copilot CLI
         if: steps.check-prs.outputs.has_prs == 'true'
-        uses: actions/setup-copilot@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: curl -fsSL https://gh.io/copilot-install | bash
 
       - name: Initialize Copilot agent (haiku model)
         if: steps.check-prs.outputs.has_prs == 'true'

--- a/.github/workflows/scheduled-copilot-agent.yml
+++ b/.github/workflows/scheduled-copilot-agent.yml
@@ -36,8 +36,12 @@ jobs:
       - name: Setup GitHub Copilot CLI
         if: steps.check-prs.outputs.has_prs == 'true'
         run: |
-          curl --fail --silent --show-error --location https://gh.io/copilot-install -o /tmp/copilot-install.sh
-          bash /tmp/copilot-install.sh
+          set -euo pipefail
+          tmp="$(mktemp)"
+          curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 https://gh.io/copilot-install -o "$tmp"
+          bash "$tmp"
+          rm -f "$tmp"
+          copilot --version
 
       - name: Initialize Copilot agent (haiku model)
         if: steps.check-prs.outputs.has_prs == 'true'


### PR DESCRIPTION
The `Manager Agent` workflow failed with:

> Unable to resolve action `actions/setup-copilot`, not found

`actions/setup-copilot` is not a published GitHub Action. This PR replaces that step with the official Copilot CLI install script from `https://gh.io/copilot-install`.

For organization-billed Copilot usage, it also adds `copilot-requests: write` to the workflow permissions and removes the `COPILOT_GITHUB_TOKEN` variable, which is ignored when the `copilot-requests` permission is set.

Org admins must enable **"Allow use of Copilot CLI billed to the organization"** in Copilot policy settings.