### PR TITLE
chore(dependabot): widen groups to include minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,7 @@ updates:
           - "*prettier*"
           - "*test*"
         update-types:
+          - "minor"
           - "patch"
     # Specify labels for npm pull requests
     labels:
@@ -43,6 +44,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     # Specify labels for GitHub Actions pull requests
     labels:
       - "github-actions"


### PR DESCRIPTION
Widens the Dependabot grouping rules so minor updates are grouped instead of opened as individual PRs.

### Changes
- `production-dependencies` group now includes **minor** and **patch** updates (was patch only)
- Added a `github-actions` group for **minor** and **patch** action updates

### Why
Currently, every npm minor update (e.g. `@opennextjs/cloudflare`, `@commitlint/cli`, `wrangler`, `@cyclonedx/cdxgen`) gets its own PR because the `production-dependencies` group only allowed patch updates. Major updates will still be individual PRs, which is the intended behavior.

Note: GitHub Actions major version bumps (e.g. `actions/checkout@v4 → @v7`) will still be individual PRs because this group is limited to minor/patch.
