### PR TITLE
chore(dependabot): align npm cooldown with pnpm v11 minimumReleaseAge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
       interval: "weekly"
     # Limit to security updates only
     open-pull-requests-limit: 10
+    # Align with pnpm v11 default minimumReleaseAge (1 day / 1440 minutes)
+    cooldown:
+      default-days: 1
     versioning-strategy: increase
     ignore:
       # Ignore major version updates for zod - requires manual migration


### PR DESCRIPTION
pnpm v11 enforces a default `minimumReleaseAge` of 1440 minutes (1 day). Without a matching cooldown, Dependabot can open PRs for packages that are too fresh for `pnpm install --frozen-lockfile` to accept, causing CI failures like:

```
ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION
```

This change adds `cooldown: default-days: 1` to the npm update configuration so Dependabot only proposes versions that are at least one day old, matching the pnpm default.

Closes the recurring age-gap between Dependabot PRs and pnpm's lockfile verification.
