### PR TITLE
fix: include TanStack Intent skills in published tarball

### DIFF
--- a/scripts/prepare-package.cjs
+++ b/scripts/prepare-package.cjs
@@ -75,6 +75,19 @@ const main = () => {
     path.join(__dirname, "../scripts/appwarden-link.cjs"),
     path.join(__dirname, "../build/scripts/appwarden-link.cjs"),
   )
+  // Copy skills directory to build directory so the TanStack Intent registry
+  // can discover them in the published tarball. Exclude _artifacts because
+  // this is a single-package repo and artifacts are only for local validation.
+  // See: https://tanstack.com/intent/latest/docs/registry
+  const skillsSrc = path.join(__dirname, "../skills")
+  const skillsDest = path.join(__dirname, "../build/skills")
+  if (fs.existsSync(skillsSrc)) {
+    fs.cpSync(skillsSrc, skillsDest, { recursive: true })
+    const artifactsDir = path.join(skillsDest, "_artifacts")
+    if (fs.existsSync(artifactsDir)) {
+      fs.rmSync(artifactsDir, { recursive: true, force: true })
+    }
+  }
 }
 
 main()

--- a/src/adapters/tanstack-start-cloudflare.ts
+++ b/src/adapters/tanstack-start-cloudflare.ts
@@ -80,8 +80,7 @@ export type {
  * Accepts pre-transformation input types (e.g., string | boolean for debug, string | object for CSP directives).
  */
 export type TanStackStartConfigFn = () =>
-  | TanStackStartCloudflareConfigInput
-  | TanStackStartCloudflareConfig
+  TanStackStartCloudflareConfigInput | TanStackStartCloudflareConfig
 
 /**
  * The result returned by the `next()` function in TanStack Start request middleware.
@@ -129,8 +128,7 @@ export interface TanStackStartNextOptions<
 }
 
 export type TanStackStartNextFnResult =
-  | Promise<TanStackStartNextResult>
-  | TanStackStartNextResult
+  Promise<TanStackStartNextResult> | TanStackStartNextResult
 
 export type TanStackStartNextFn = <TServerContext = Record<string, unknown>>(
   options?: TanStackStartNextOptions<TServerContext>,

--- a/src/schemas/use-content-security-policy.ts
+++ b/src/schemas/use-content-security-policy.ts
@@ -42,8 +42,7 @@ export const UseCSPInputSchema = z.object({
   ).transform(
     (val) =>
       (typeof val === "string" ? JSON.parse(val) : val) as
-        | ContentSecurityPolicyType
-        | undefined,
+        ContentSecurityPolicyType | undefined,
   ),
 })
 

--- a/src/schemas/vercel.ts
+++ b/src/schemas/vercel.ts
@@ -59,8 +59,7 @@ export const VercelCSPSchema = z.object({
     .transform(
       (val) =>
         (typeof val === "string" ? JSON.parse(val) : val) as
-          | ContentSecurityPolicyType
-          | undefined,
+          ContentSecurityPolicyType | undefined,
     ),
 })
 


### PR DESCRIPTION
The TanStack Intent registry discovers packages by the `tanstack-intent` keyword and extracts `skills/**/SKILL.md` from the published npm tarball.

Because this package is published from `build/` (`pkgRoot: "build"` in `.releaserc`), `skills/` was not included in the tarball. This change copies `skills/` into `build/skills/` during `prepare-package.cjs` and excludes `skills/_artifacts` per the single-package convention.

Verified:
- `pnpm build && node scripts/prepare-package.cjs` succeeds
- `build/skills/` contains 10 `SKILL.md` files
- `build/skills/_artifacts` is excluded
- `pnpm test` passes (933 tests)