### PR TITLE
docs: add TanStack Intent consumer setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ npx @tanstack/intent@latest hooks install
 Then load a specific skill when working on a task:
 
 ```bash
-npx @tanstack/intent@latest load @appwarden/middleware/appwarden-middleware-get-started
+npx @tanstack/intent@latest load @appwarden/middleware#appwarden-middleware-get-started
 ```
 
 List available skills:

--- a/README.md
+++ b/README.md
@@ -279,7 +279,31 @@ Nonce-based CSP (`{{nonce}}`) is **not supported** in Vercel Edge Middleware; CS
 
 ## Agent skills
 
-This repository includes [TanStack Intent](https://tanstack.com/intent) skills under `skills/` so coding agents can discover and apply Appwarden installation, configuration, and troubleshooting guidance. Load them with the `@tanstack/intent` CLI or any compatible agent.
+This repository ships [TanStack Intent](https://tanstack.com/intent) skills under `skills/` so coding agents can discover and apply Appwarden installation, configuration, and troubleshooting guidance.
+
+After installing `@appwarden/middleware`, configure your agent to use the skills:
+
+```bash
+npx @tanstack/intent@latest install
+```
+
+For edit-time skill suggestions in Claude Code or Codex:
+
+```bash
+npx @tanstack/intent@latest hooks install
+```
+
+Then load a specific skill when working on a task:
+
+```bash
+npx @tanstack/intent@latest load @appwarden/middleware/appwarden-middleware-get-started
+```
+
+List available skills:
+
+```bash
+npx @tanstack/intent@latest list
+```
 
 ## Contributing
 


### PR DESCRIPTION
Updates the "Agent skills" README section to give consumers concrete commands for setting up TanStack Intent with this package.

Changes:
- Replaces the vague "Load them with the `@tanstack/intent` CLI" sentence with explicit commands
- Documents `intent install`, `intent hooks install`, `intent load`, and `intent list`
- Explains when to use each command

This follows the TanStack Intent consumer quick-start docs: https://tanstack.com/intent/latest/docs/getting-started/quick-start-consumers