### PR TITLE
fix: default api.basePaths to ["/"] and allow API-only locking without website config

### DIFF
--- a/scripts/appwarden-link.cjs
+++ b/scripts/appwarden-link.cjs
@@ -62,7 +62,7 @@ const ApiLockResponseSchema = z.object({
 })
 
 const ApiMiddlewareConfigSchema = z.object({
-  basePaths: z.array(z.string()),
+  basePaths: z.array(z.string()).default(["/"]),
   response: ApiLockResponseSchema.optional(),
 })
 

--- a/src/core/check-lock-status.ts
+++ b/src/core/check-lock-status.ts
@@ -24,8 +24,8 @@ export interface CheckLockConfig {
   debug?: boolean
   /** waitUntil function for background tasks (Cloudflare Workers) */
   waitUntil: (fn: Promise<unknown>) => void
-  /** The lock page slug - used to construct the context */
-  lockPageSlug: string
+  /** The lock page slug - used to construct the context (optional for API-only locking) */
+  lockPageSlug?: string
 }
 
 /**

--- a/src/middlewares/use-appwarden.test.ts
+++ b/src/middlewares/use-appwarden.test.ts
@@ -603,6 +603,86 @@ describe("useAppwarden", () => {
       )
     })
 
+    it("should return API lock response for API-only config when site is locked", async () => {
+      mockInput = {
+        ...mockInput,
+        appwardenMiddleware: [
+          {
+            url: "example.com",
+            options: {
+              api: { basePaths: ["/api"] },
+            },
+          },
+        ],
+      }
+
+      vi.mocked(checkLockStatus).mockResolvedValue({
+        isLocked: true,
+        isTestLock: false,
+      })
+
+      mockContext.request = new Request("https://example.com/api/users", {
+        headers: { accept: "application/json" },
+      })
+
+      const middleware = useAppwarden(mockInput)
+      await middleware(mockContext, mockNext)
+
+      expect(checkLockStatus).toHaveBeenCalled()
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(mockContext.response).toBeInstanceOf(Response)
+      expect(mockContext.response!.status).toBe(503)
+    })
+
+    it('should lock all paths when api.basePaths is ["/"]', async () => {
+      mockInput = {
+        ...mockInput,
+        appwardenMiddleware: [
+          {
+            url: "example.com",
+            options: {
+              api: { basePaths: ["/"] },
+            },
+          },
+        ],
+      }
+
+      vi.mocked(checkLockStatus).mockResolvedValue({
+        isLocked: true,
+        isTestLock: false,
+      })
+
+      mockContext.request = new Request("https://example.com/any-path", {
+        headers: { accept: "application/json" },
+      })
+
+      const middleware = useAppwarden(mockInput)
+      await middleware(mockContext, mockNext)
+
+      expect(checkLockStatus).toHaveBeenCalled()
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(mockContext.response).toBeInstanceOf(Response)
+      expect(mockContext.response!.status).toBe(503)
+    })
+
+    it("should pass through when route-based options are empty", async () => {
+      mockInput = {
+        ...mockInput,
+        appwardenMiddleware: [
+          {
+            url: "example.com",
+            options: {},
+          },
+        ],
+      }
+
+      const middleware = useAppwarden(mockInput)
+      await middleware(mockContext, mockNext)
+
+      expect(checkLockStatus).not.toHaveBeenCalled()
+      expect(mockNext).toHaveBeenCalled()
+    })
+
     it("should resolve lockPageSlug for matching hostname in route-based config", async () => {
       mockInput = {
         ...mockInput,

--- a/src/middlewares/use-appwarden.ts
+++ b/src/middlewares/use-appwarden.ts
@@ -49,8 +49,8 @@ export const useAppwarden: (input: CloudflareConfigType) => Middleware =
       }
 
       const lockPageSlug = routeConfig.website?.lockPageSlug
-      const hasApiBasePaths =
-        routeConfig.api?.basePaths && routeConfig.api.basePaths.length > 0
+      const apiBasePaths = routeConfig.api?.basePaths ?? []
+      const hasApiBasePaths = apiBasePaths.length > 0
 
       // Nothing to do if neither a website lock page nor API base paths are configured.
       if (!lockPageSlug && !hasApiBasePaths) {
@@ -86,9 +86,9 @@ export const useAppwarden: (input: CloudflareConfigType) => Middleware =
       // Locked: API base paths return the configured API response.
       if (
         hasApiBasePaths &&
-        pathMatchesAnyPattern(requestUrl.pathname, routeConfig.api!.basePaths)
+        pathMatchesAnyPattern(requestUrl.pathname, apiBasePaths)
       ) {
-        const responseConfig = routeConfig.api!.response
+        const responseConfig = routeConfig.api?.response
         debugFn("API base path matched - returning API lock response")
         context.response = new Response(responseConfig?.body ?? "", {
           status: responseConfig?.status ?? 503,

--- a/src/middlewares/use-appwarden.ts
+++ b/src/middlewares/use-appwarden.ts
@@ -49,21 +49,22 @@ export const useAppwarden: (input: CloudflareConfigType) => Middleware =
       }
 
       const lockPageSlug = routeConfig.website?.lockPageSlug
-      if (!lockPageSlug) {
+      const hasApiBasePaths =
+        routeConfig.api?.basePaths && routeConfig.api.basePaths.length > 0
+
+      // Nothing to do if neither a website lock page nor API base paths are configured.
+      if (!lockPageSlug && !hasApiBasePaths) {
         return
       }
 
       // Skip lock check for non-HTML requests when there are no API base paths.
       // This preserves the legacy behavior of not touching API/static traffic.
-      const hasApiBasePaths =
-        routeConfig.api?.basePaths && routeConfig.api.basePaths.length > 0
       if (!isHTMLRequest(request) && !hasApiBasePaths) {
         return
       }
 
-      // Skip if already on lock page to prevent infinite redirect loop and
-      // avoid unnecessary lock status checks.
-      if (isOnLockPage(lockPageSlug, request.url)) {
+      // Skip if already on the website lock page to prevent infinite redirect loop.
+      if (lockPageSlug && isOnLockPage(lockPageSlug, request.url)) {
         return
       }
 
@@ -84,11 +85,10 @@ export const useAppwarden: (input: CloudflareConfigType) => Middleware =
 
       // Locked: API base paths return the configured API response.
       if (
-        routeConfig.api?.basePaths &&
-        routeConfig.api.basePaths.length > 0 &&
-        pathMatchesAnyPattern(requestUrl.pathname, routeConfig.api.basePaths)
+        hasApiBasePaths &&
+        pathMatchesAnyPattern(requestUrl.pathname, routeConfig.api!.basePaths)
       ) {
-        const responseConfig = routeConfig.api.response
+        const responseConfig = routeConfig.api!.response
         debugFn("API base path matched - returning API lock response")
         context.response = new Response(responseConfig?.body ?? "", {
           status: responseConfig?.status ?? 503,
@@ -104,9 +104,11 @@ export const useAppwarden: (input: CloudflareConfigType) => Middleware =
       }
 
       // Locked: redirect to the website lock page
-      const lockPageUrl = buildLockPageUrl(lockPageSlug, request.url)
-      context.response = createRedirect(lockPageUrl)
-      shouldCallNext = false
+      if (lockPageSlug) {
+        const lockPageUrl = buildLockPageUrl(lockPageSlug, request.url)
+        context.response = createRedirect(lockPageUrl)
+        shouldCallNext = false
+      }
     } catch (e) {
       const message =
         "Appwarden encountered an unknown error. Please contact Appwarden support at https://appwarden.io/join-community."

--- a/src/runners/appwarden-on-vercel.test.ts
+++ b/src/runners/appwarden-on-vercel.test.ts
@@ -990,6 +990,98 @@ describe("createAppwardenMiddleware", () => {
       )
     })
 
+    it("should return API lock response for API-only config when site is locked", async () => {
+      const routeConfig = {
+        ...mockConfig,
+        appwardenMiddleware: [
+          {
+            url: "example.com",
+            options: {
+              api: { basePaths: ["/api"] },
+            },
+          },
+        ],
+      }
+      vi.mocked(AppwardenConfigSchemaMock.parse).mockReturnValue(routeConfig)
+      vi.mocked(getLockValueMock).mockResolvedValue({
+        lockValue: {
+          isLocked: 1,
+          isLockedTest: 0,
+          lastCheck: Date.now(),
+        },
+        shouldDeleteEdgeValue: false,
+      })
+
+      const middleware = createAppwardenMiddleware(routeConfig)
+      const result = await middleware(
+        new Request("https://example.com/api/users", {
+          headers: { accept: "application/json" },
+        }),
+      )
+
+      expect(getLockValueMock).toHaveBeenCalled()
+      expect(result.status).toBe(503)
+      expect(mockNextResponseNext).not.toHaveBeenCalled()
+    })
+
+    it('should lock all paths when api.basePaths is ["/"]', async () => {
+      const routeConfig = {
+        ...mockConfig,
+        appwardenMiddleware: [
+          {
+            url: "example.com",
+            options: {
+              api: { basePaths: ["/"] },
+            },
+          },
+        ],
+      }
+      vi.mocked(AppwardenConfigSchemaMock.parse).mockReturnValue(routeConfig)
+      vi.mocked(getLockValueMock).mockResolvedValue({
+        lockValue: {
+          isLocked: 1,
+          isLockedTest: 0,
+          lastCheck: Date.now(),
+        },
+        shouldDeleteEdgeValue: false,
+      })
+
+      const middleware = createAppwardenMiddleware(routeConfig)
+      const result = await middleware(
+        new Request("https://example.com/any-path", {
+          headers: { accept: "application/json" },
+        }),
+      )
+
+      expect(getLockValueMock).toHaveBeenCalled()
+      expect(result.status).toBe(503)
+      expect(mockNextResponseNext).not.toHaveBeenCalled()
+    })
+
+    it("should pass through when route-based options are empty", async () => {
+      const routeConfig = {
+        ...mockConfig,
+        appwardenMiddleware: [
+          {
+            url: "example.com",
+            options: {},
+          },
+        ],
+      }
+      vi.mocked(AppwardenConfigSchemaMock.parse).mockReturnValue(routeConfig)
+
+      const middleware = createAppwardenMiddleware(routeConfig)
+      const result = await middleware(
+        new Request("https://example.com/page", {
+          headers: { accept: "text/html" },
+        }),
+      )
+
+      expect(getLockValueMock).not.toHaveBeenCalled()
+      expect(result.status).toBe(200)
+      expect(mockNextResponseNext).toHaveBeenCalled()
+    })
+
     it("should skip protection when hostname does not match any route config", async () => {
       const routeConfig = {
         ...mockConfig,

--- a/src/runners/appwarden-on-vercel.ts
+++ b/src/runners/appwarden-on-vercel.ts
@@ -143,22 +143,23 @@ export function createAppwardenMiddleware(
       }
 
       const lockPageSlug = routeConfig.website?.lockPageSlug
-      if (!lockPageSlug) {
-        debugFn("No lock page configured - passing through")
+      const hasApiBasePaths =
+        routeConfig.api?.basePaths && routeConfig.api.basePaths.length > 0
+
+      // Pass through if neither a website lock page nor API base paths are configured.
+      if (!lockPageSlug && !hasApiBasePaths) {
+        debugFn("No lock page or API base paths configured - passing through")
         return applyCspHeaders(NextResponse.next())
       }
 
-      // Skip if already on lock page to prevent infinite redirect loop and
-      // avoid unnecessary lock status checks.
-      if (isOnLockPage(lockPageSlug, request.url)) {
+      // Skip if already on the website lock page to prevent infinite redirect loop.
+      if (lockPageSlug && isOnLockPage(lockPageSlug, request.url)) {
         debugFn("Already on lock page - passing through")
         return applyCspHeaders(NextResponse.next())
       }
 
       // Skip lock check and CSP for non-HTML requests when there are no API base paths.
       // This preserves the legacy behavior of not touching API/static traffic.
-      const hasApiBasePaths =
-        routeConfig.api?.basePaths && routeConfig.api.basePaths.length > 0
       if (!isHTMLRequest(request) && !hasApiBasePaths) {
         debugFn("Non-HTML request without API base paths - passing through")
         return NextResponse.next()
@@ -212,11 +213,10 @@ export function createAppwardenMiddleware(
 
       // Locked: API base paths return the configured API response.
       if (
-        routeConfig.api?.basePaths &&
-        routeConfig.api.basePaths.length > 0 &&
-        pathMatchesAnyPattern(requestUrl.pathname, routeConfig.api.basePaths)
+        hasApiBasePaths &&
+        pathMatchesAnyPattern(requestUrl.pathname, routeConfig.api!.basePaths)
       ) {
-        const responseConfig = routeConfig.api.response
+        const responseConfig = routeConfig.api!.response
         debugFn("API base path matched - returning API lock response")
         return new Response(responseConfig?.body ?? "", {
           status: responseConfig?.status ?? 503,
@@ -231,12 +231,17 @@ export function createAppwardenMiddleware(
       }
 
       // Locked: redirect to the website lock page
-      debugFn(`Website is locked - redirecting to ${lockPageSlug}`)
-      const lockPageUrl = buildLockPageUrl(lockPageSlug, request.url)
-      const redirectResponse = createMutableRedirectResponse(
-        lockPageUrl.toString(),
-      )
-      return applyCspHeaders(redirectResponse)
+      if (lockPageSlug) {
+        debugFn(`Website is locked - redirecting to ${lockPageSlug}`)
+        const lockPageUrl = buildLockPageUrl(lockPageSlug, request.url)
+        const redirectResponse = createMutableRedirectResponse(
+          lockPageUrl.toString(),
+        )
+        return applyCspHeaders(redirectResponse)
+      }
+
+      // No website lock page configured; pass through.
+      return applyCspHeaders(NextResponse.next())
     } catch (e) {
       debugFn(
         "Error in Appwarden Vercel middleware",

--- a/src/runners/appwarden-on-vercel.ts
+++ b/src/runners/appwarden-on-vercel.ts
@@ -143,8 +143,8 @@ export function createAppwardenMiddleware(
       }
 
       const lockPageSlug = routeConfig.website?.lockPageSlug
-      const hasApiBasePaths =
-        routeConfig.api?.basePaths && routeConfig.api.basePaths.length > 0
+      const apiBasePaths = routeConfig.api?.basePaths ?? []
+      const hasApiBasePaths = apiBasePaths.length > 0
 
       // Pass through if neither a website lock page nor API base paths are configured.
       if (!lockPageSlug && !hasApiBasePaths) {
@@ -214,9 +214,9 @@ export function createAppwardenMiddleware(
       // Locked: API base paths return the configured API response.
       if (
         hasApiBasePaths &&
-        pathMatchesAnyPattern(requestUrl.pathname, routeConfig.api!.basePaths)
+        pathMatchesAnyPattern(requestUrl.pathname, apiBasePaths)
       ) {
-        const responseConfig = routeConfig.api!.response
+        const responseConfig = routeConfig.api?.response
         debugFn("API base path matched - returning API lock response")
         return new Response(responseConfig?.body ?? "", {
           status: responseConfig?.status ?? 503,

--- a/src/schemas/middleware-config.test.ts
+++ b/src/schemas/middleware-config.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest"
-import { WebsiteMiddlewareConfigSchema } from "./middleware-config"
+import {
+  ApiMiddlewareConfigSchema,
+  WebsiteMiddlewareConfigSchema,
+} from "./middleware-config"
 
 describe("WebsiteMiddlewareConfigSchema", () => {
   it("parses a valid JSON string for cspDirectives", () => {
@@ -38,5 +41,25 @@ describe("WebsiteMiddlewareConfigSchema", () => {
         "cspDirectives must be a valid JSON string",
       )
     }
+  })
+})
+
+describe("ApiMiddlewareConfigSchema", () => {
+  it('defaults basePaths to ["/"] when omitted', () => {
+    const result = ApiMiddlewareConfigSchema.safeParse({
+      response: { status: 503, body: "Service unavailable" },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.basePaths).toEqual(["/"])
+  })
+
+  it("preserves explicit basePaths when provided", () => {
+    const result = ApiMiddlewareConfigSchema.safeParse({
+      basePaths: ["/api", "/internal"],
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.basePaths).toEqual(["/api", "/internal"])
   })
 })

--- a/src/schemas/middleware-config.ts
+++ b/src/schemas/middleware-config.ts
@@ -22,7 +22,7 @@ export const ApiLockResponseSchema = z.object({
 export type ApiLockResponse = z.infer<typeof ApiLockResponseSchema>
 
 export const ApiMiddlewareConfigSchema = z.object({
-  basePaths: z.array(z.string()),
+  basePaths: z.array(z.string()).default(["/"]),
   response: ApiLockResponseSchema.optional(),
 })
 

--- a/src/schemas/use-appwarden.test.ts
+++ b/src/schemas/use-appwarden.test.ts
@@ -357,4 +357,27 @@ describe("UseAppwardenInputSchema", () => {
     const result = RefinedSchema.safeParse(validInput)
     expect(result.success).toBe(true)
   })
+
+  it('should default api.basePaths to ["/"] when omitted in route-based config', () => {
+    const validInput = {
+      debug: true,
+      appwardenApiToken: "token123",
+      appwardenMiddleware: [
+        {
+          url: "example.com",
+          options: {
+            api: {},
+          },
+        },
+      ],
+    }
+
+    const result = UseAppwardenInputSchema.safeParse(validInput)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(
+        result.data.appwardenMiddleware?.[0].options.api?.basePaths,
+      ).toEqual(["/"])
+    }
+  })
 })

--- a/src/types/cloudflare.ts
+++ b/src/types/cloudflare.ts
@@ -61,7 +61,7 @@ export type CloudflareProviderContext = Omit<
   provider: "cloudflare-cache"
   edgeCache: JSONStore<LockValueType>
   waitUntil: NextFetchEvent["waitUntil"]
-  lockPageSlug: string // Required - context is only created when lockPageSlug is resolved
+  lockPageSlug?: string // Optional - allows API-only locking without a website lock page
   appwardenApiHostname?: string
   debug: (...msg: any[]) => void
 }


### PR DESCRIPTION
## Summary

This patch makes the route-based middleware configuration more forgiving by:

1. **Defaulting `api.basePaths` to `["/"]`** at the Zod schema level when `api` is provided without explicit base paths.
2. **Allowing API-only locking** when `website` is omitted but `api` is configured. Previously, the middleware would short-circuit and do nothing because it required a `lockPageSlug` before checking the lock status.

## Changes

- `src/schemas/middleware-config.ts`: `ApiMiddlewareConfigSchema.basePaths` now defaults to `["/"]`.
- `scripts/appwarden-link.cjs`: same default applied to the generated config schema for consistency.
- `src/core/check-lock-status.ts` & `src/types/cloudflare.ts`: `lockPageSlug` is now optional, enabling API-only lock checks.
- `src/middlewares/use-appwarden.ts`: no longer early-returns when `website` is missing; proceeds to check lock status and serve API lock responses when `api` is configured.
- `src/runners/appwarden-on-vercel.ts`: same runtime handling for the Vercel runner.
- Tests added/updated in:
  - `src/schemas/middleware-config.test.ts`
  - `src/schemas/use-appwarden.test.ts`
  - `src/middlewares/use-appwarden.test.ts`
  - `src/runners/appwarden-on-vercel.test.ts`

## Verification

- `pnpm test` — 992 tests passed
- `pnpm test:vercel` — 37 tests passed
- `pnpm check:types` — passed
- `pnpm build` — passed

## Release note

Patch release: fixes partial middleware option handling so missing `website` and `api.basePaths` default gracefully.