### PR TITLE
docs: update skills docs for new input configuration schema

### DIFF
--- a/skills/_artifacts/domain_map.yaml
+++ b/skills/_artifacts/domain_map.yaml
@@ -56,12 +56,16 @@ skills:
         wrong_pattern: |
           createAppwardenMiddleware({
             appwardenApiToken: "sk_test_...",
-            lockPageSlug: "/maintenance",
+            website: {
+              lockPageSlug: "/maintenance",
+            },
           })
         correct_pattern: |
           createAppwardenMiddleware({
             appwardenApiToken: process.env.APPWARDEN_API_TOKEN!,
-            lockPageSlug: "/maintenance",
+            website: {
+              lockPageSlug: "/maintenance",
+            },
           })
         source: "src/schemas/helpers.ts AppwardenApiTokenSchema and README Configuration > appwardenApiToken"
         priority: "CRITICAL"
@@ -96,12 +100,16 @@ skills:
         wrong_pattern: |
           createAppwardenMiddleware({
             appwardenApiToken: env.APPWARDEN_API_TOKEN,
-            lockPageSlug: "/maintenance",
+            website: {
+              lockPageSlug: "/maintenance",
+            },
           })
         correct_pattern: |
           createAppwardenMiddleware({
             appwardenApiToken: env.APPWARDEN_API_TOKEN,
-            lockPageSlug: "/maintenance",
+            website: {
+              lockPageSlug: "/maintenance",
+            },
             debug: true,
           })
         source: "src/schemas/use-appwarden.ts BooleanSchema default false"
@@ -238,16 +246,16 @@ skills:
       - mistake: "Using nonce-based CSP on the Next.js Cloudflare adapter"
         mechanism: "The OpenNext adapter applies CSP headers only before origin; it does not rewrite HTML or inject nonces, so {{nonce}} placeholders will not work."
         wrong_pattern: |
-          contentSecurityPolicy: {
-            mode: "enforced",
-            directives: {
+          website: {
+            cspMode: "enforced",
+            cspDirectives: {
               "script-src": ["'self'", "{{nonce}}"],
             },
           }
         correct_pattern: |
-          contentSecurityPolicy: {
-            mode: "enforced",
-            directives: {
+          website: {
+            cspMode: "enforced",
+            cspDirectives: {
               "script-src": ["'self'"],
             },
           }
@@ -503,14 +511,14 @@ skills:
       - mistake: "Including {{nonce}} in CSP directives for Vercel"
         mechanism: "Vercel Edge Middleware cannot rewrite HTML to inject nonces, so the schema rejects {{nonce}} placeholders on Vercel."
         wrong_pattern: |
-          contentSecurityPolicy: {
-            mode: "enforced",
-            directives: { "script-src": ["'self'", "{{nonce}}"] },
+          website: {
+            cspMode: "enforced",
+            cspDirectives: { "script-src": ["'self'", "{{nonce}}"] },
           }
         correct_pattern: |
-          contentSecurityPolicy: {
-            mode: "enforced",
-            directives: { "default-src": ["'self'"] },
+          website: {
+            cspMode: "enforced",
+            cspDirectives: { "default-src": ["'self'"] },
           }
         source: "src/schemas/vercel.ts VercelCSPSchema, README Feature Compatibility, and vercel-middleware-integration.mdx"
         priority: "HIGH"
@@ -625,15 +633,15 @@ skills:
       - mistake: "Using {{nonce}} on a platform that does not support HTML rewriting"
         mechanism: "Nonce placeholders are only rewritten on Cloudflare Workers and Cloudflare framework adapters with HTML rewriting; Vercel and Next.js on Cloudflare (OpenNext) silently leave the placeholder in the header."
         wrong_pattern: |
-          contentSecurityPolicy: {
-            mode: "enforced",
-            directives: { "script-src": ["'self'", "{{nonce}}"] },
+          website: {
+            cspMode: "enforced",
+            cspDirectives: { "script-src": ["'self'", "{{nonce}}"] },
           }
         correct_pattern: |
           // Use headers-only CSP on Vercel / OpenNext
-          contentSecurityPolicy: {
-            mode: "enforced",
-            directives: { "default-src": ["'self'"] },
+          website: {
+            cspMode: "enforced",
+            cspDirectives: { "default-src": ["'self'"] },
           }
         source: "README Feature Compatibility and src/schemas/vercel.ts VercelCSPSchema"
         priority: "CRITICAL"
@@ -648,15 +656,15 @@ skills:
         mechanism: "Nonce-based CSP is Cloudflare-only because Vercel cannot rewrite HTML to inject nonces; Appwarden CSP on Vercel is headers-only."
         wrong_pattern: |
           // middleware.ts on Vercel
-          contentSecurityPolicy: {
-            mode: "enforced",
-            directives: { "script-src": ["'self'", "{{nonce}}"] },
+          website: {
+            cspMode: "enforced",
+            cspDirectives: { "script-src": ["'self'", "{{nonce}}"] },
           }
         correct_pattern: |
           // Use a headers-only CSP on Vercel, or move to Cloudflare for nonce support
-          contentSecurityPolicy: {
-            mode: "enforced",
-            directives: { "default-src": ["'self'"] },
+          website: {
+            cspMode: "enforced",
+            cspDirectives: { "default-src": ["'self'"] },
           }
         source: "managing-content-security-policy.mdx Warning and README Feature Compatibility"
         priority: "CRITICAL"
@@ -669,11 +677,11 @@ skills:
       - mistake: "Starting CSP in enforced mode before validating directives"
         mechanism: "Enforced mode blocks violations immediately; report-only lets developers collect violations and fix them before enforcement."
         wrong_pattern: |
-          contentSecurityPolicy: { mode: "enforced", directives: { ... } }
+          website: { cspMode: "enforced", cspDirectives: { ... } }
         correct_pattern: |
-          contentSecurityPolicy: { mode: "report-only", directives: { ... } }
+          website: { cspMode: "report-only", cspDirectives: { ... } }
           // Switch to enforced after no violations are reported
-        source: "README Configuration > contentSecurityPolicy and managing-content-security-policy.mdx Enablement"
+        source: "README Configuration > website.cspMode/cspDirectives and managing-content-security-policy.mdx Enablement"
         priority: "MEDIUM"
         status: "active"
       - mistake: "Passing CSP_DIRECTIVES as a malformed JSON string"
@@ -706,29 +714,29 @@ skills:
   - name: "Create and configure Appwarden lock page"
     slug: "create-and-configure-lock-page"
     domain: "security-configuration"
-    description: "Build a neutral maintenance-style lock page and connect it to Appwarden lockPageSlug."
+    description: "Build a neutral maintenance-style lock page and connect it to Appwarden website.lockPageSlug."
     type: "core"
     covers:
       [
         "lock page route and template",
         "neutral messaging and UX",
         "linking back to main homepage",
-        "lockPageSlug validation and defaults",
+        "website.lockPageSlug validation and defaults",
       ]
     tasks:
       [
         "Scaffold a lock page route in the target framework",
         "Use neutral “maintenance” messaging plus homepage link",
-        "Configure lockPageSlug to point at the new route",
+        "Configure website.lockPageSlug to point at the new route",
       ]
     failure_modes:
-      - mistake: "Configuring a lockPageSlug that does not exist as a route"
+      - mistake: "Configuring a website.lockPageSlug that does not exist as a route"
         mechanism: "If the lock page route is missing, quarantined visitors receive 404s instead of the maintenance page."
         wrong_pattern: |
-          lockPageSlug: "/lockdown" // no /lockdown route in the app
+          website: { lockPageSlug: "/lockdown" } // no /lockdown route in the app
         correct_pattern: |
-          lockPageSlug: "/maintenance" // with a real /maintenance page
-        source: "README Configuration > lockPageSlug"
+          website: { lockPageSlug: "/maintenance" } // with a real /maintenance page
+        source: "README Configuration > website.lockPageSlug"
         priority: "HIGH"
         status: "active"
       - mistake: "Using incident-specific or alarming messaging on the lock page"
@@ -741,12 +749,12 @@ skills:
         source: "intent-log.md Turn 17"
         priority: "MEDIUM"
         status: "active"
-      - mistake: "Providing an absolute URL or protocol-relative lockPageSlug"
-        mechanism: "The schema rejects slugs containing ://, starting with //, or containing backslashes; lockPageSlug must be a relative path."
+      - mistake: "Providing an absolute URL or protocol-relative website.lockPageSlug"
+        mechanism: "The schema rejects slugs containing ://, starting with //, or containing backslashes; website.lockPageSlug must be a relative path."
         wrong_pattern: |
-          lockPageSlug: "https://example.com/maintenance"
+          website: { lockPageSlug: "https://example.com/maintenance" }
         correct_pattern: |
-          lockPageSlug: "/maintenance"
+          website: { lockPageSlug: "/maintenance" }
         source: "src/schemas/helpers.ts ValidLockPageSlugSchema"
         priority: "MEDIUM"
         status: "active"

--- a/skills/_artifacts/skill_spec.md
+++ b/skills/_artifacts/skill_spec.md
@@ -21,7 +21,7 @@
 | Wire Appwarden into Vercel Edge Middleware            | framework | Middleware integration                | Vercel Edge Middleware, matcher/runtime, Upstash KV and Edge Config cache provider selection, Edge Config endpoint/reads, Deployment Protection bypass | 10            |
 | Manage Appwarden API token in dashboard               | core      | Security & policy configuration       | Creating, rotating, and revoking API tokens (Settings > Security)                                                                                      | 4             |
 | Configure nonce-based CSP on Cloudflare               | core      | Security & policy configuration       | Nonce CSP config, domain configuration file, redeploy workflow                                                                                         | 6             |
-| Create and configure Appwarden lock page              | core      | Security & policy configuration       | Lock page route, UX, lockPageSlug validation                                                                                                           | 3             |
+| Create and configure Appwarden lock page              | core      | Security & policy configuration       | Lock page route, UX, website.lockPageSlug validation                                                                                                   | 3             |
 | Quarantine, unlock, and test a domain                 | lifecycle | Operations, testing & troubleshooting | Quarantine/test/unlock flows, heartbeat verification, Discord permissions, dashboard UI path                                                           | 5             |
 | Verify setup before production and debug issues       | lifecycle | Operations, testing & troubleshooting | Pre-launch checklist, domain verification, incident simulation, debug cleanup                                                                          | 5             |
 
@@ -107,11 +107,11 @@
 
 ### Create and configure Appwarden lock page (3 failure modes)
 
-| #   | Mistake                                                        | Priority | Source                 | Cross-skill? |
-| --- | -------------------------------------------------------------- | -------- | ---------------------- | ------------ |
-| 1   | Configuring a lockPageSlug that does not exist as a route      | HIGH     | README                 | —            |
-| 2   | Using incident-specific or alarming messaging on the lock page | MEDIUM   | intent-log.md          | —            |
-| 3   | Providing an absolute URL or protocol-relative lockPageSlug    | MEDIUM   | src/schemas/helpers.ts | —            |
+| #   | Mistake                                                             | Priority | Source                 | Cross-skill? |
+| --- | ------------------------------------------------------------------- | -------- | ---------------------- | ------------ |
+| 1   | Configuring a website.lockPageSlug that does not exist as a route   | HIGH     | README                 | —            |
+| 2   | Using incident-specific or alarming messaging on the lock page      | MEDIUM   | intent-log.md          | —            |
+| 3   | Providing an absolute URL or protocol-relative website.lockPageSlug | MEDIUM   | src/schemas/helpers.ts | —            |
 
 ### Quarantine, unlock, and test a domain (5 failure modes)
 

--- a/skills/_artifacts/skill_tree.yaml
+++ b/skills/_artifacts/skill_tree.yaml
@@ -61,7 +61,7 @@ skills:
     type: "core"
     domain: "security-configuration"
     path: "skills/appwarden-middleware-lock-page/SKILL.md"
-    description: "Build a neutral maintenance-style lock page and connect it to Appwarden lockPageSlug."
+    description: "Build a neutral maintenance-style lock page and connect it to Appwarden website.lockPageSlug."
     requires:
       - "appwarden-middleware-get-started"
     sources:

--- a/skills/appwarden-middleware-csp/SKILL.md
+++ b/skills/appwarden-middleware-csp/SKILL.md
@@ -102,9 +102,9 @@ Wrong:
 
 ```typescript
 // middleware.ts on Vercel
-contentSecurityPolicy: {
-  mode: 'enforced',
-  directives: { 'script-src': ["'self'", '{{nonce}}"] },
+website: {
+  cspMode: 'enforced',
+  cspDirectives: { 'script-src': ["'self'", '{{nonce}}"] },
 }
 ```
 
@@ -112,9 +112,9 @@ Correct:
 
 ```typescript
 // Vercel: headers-only CSP, or move to Cloudflare for nonce support
-contentSecurityPolicy: {
-  mode: 'enforced',
-  directives: { 'default-src': ["'self'"] },
+website: {
+  cspMode: 'enforced',
+  cspDirectives: { 'default-src': ["'self'"] },
 }
 ```
 

--- a/skills/appwarden-middleware-get-started/SKILL.md
+++ b/skills/appwarden-middleware-get-started/SKILL.md
@@ -138,7 +138,9 @@ export default createAppwardenMiddleware(
     {},
     {
       appwardenApiToken: process.env.APPWARDEN_API_TOKEN,
-      lockPageSlug: "/maintenance",
+      website: {
+        lockPageSlug: "/maintenance",
+      },
       cacheUrl: process.env.KV_URL,
       debug: true,
     },
@@ -182,7 +184,9 @@ Wrong:
 ```typescript
 export default createAppwardenMiddleware({
   appwardenApiToken: "sk_test_...",
-  lockPageSlug: "/maintenance",
+  website: {
+    lockPageSlug: "/maintenance",
+  },
 })
 ```
 
@@ -257,7 +261,9 @@ Wrong:
 ```typescript
 export default createAppwardenMiddleware({
   appwardenApiToken: process.env.APPWARDEN_API_TOKEN,
-  lockPageSlug: "/maintenance",
+  website: {
+    lockPageSlug: "/maintenance",
+  },
 })
 ```
 
@@ -274,7 +280,9 @@ export default createAppwardenMiddleware(
     {},
     {
       appwardenApiToken: process.env.APPWARDEN_API_TOKEN,
-      lockPageSlug: "/maintenance",
+      website: {
+        lockPageSlug: "/maintenance",
+      },
       cacheUrl: process.env.KV_URL,
       debug: true,
     },

--- a/skills/appwarden-middleware-lock-page/SKILL.md
+++ b/skills/appwarden-middleware-lock-page/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: appwarden-middleware-lock-page
 description: >
-  Build a neutral maintenance-style lock page, route it in the target framework, and connect it to Appwarden via lockPageSlug. Provides a minimal HTML/JSX template that works on Cloudflare and Vercel. Load this skill when a user is setting up their first lock page.
+  Build a neutral maintenance-style lock page, route it in the target framework, and connect it to Appwarden via website.lockPageSlug. Provides a minimal HTML/JSX template that works on Cloudflare and Vercel. Load this skill when a user is setting up their first lock page.
 metadata:
   type: core
   library: "@appwarden/middleware"
@@ -13,13 +13,13 @@ sources:
 
 # Appwarden Middleware — Create and Configure Lock Page
 
-A lock page is the page users see when a domain is quarantined. It must exist as a real route, use neutral maintenance language, and link back to the homepage. This skill provides a minimal template and shows how to wire it to `lockPageSlug`.
+A lock page is the page users see when a domain is quarantined. It must exist as a real route, use neutral maintenance language, and link back to the homepage. This skill provides a minimal template and shows how to wire it to `website.lockPageSlug`.
 
 ## Setup
 
 1. Create a route in your framework at the path you want to use for the lock page (for example, `/maintenance`).
 2. Add a page component that returns the lock page template below.
-3. Set `lockPageSlug` in the middleware to match that path.
+3. Set `website.lockPageSlug` in the middleware to match that path.
 
 ## Core Patterns
 
@@ -78,7 +78,7 @@ export default function MaintenancePage() {
 </html>
 ```
 
-### Wire lockPageSlug to the route
+### Wire website.lockPageSlug to the route
 
 ```typescript
 import {
@@ -90,26 +90,32 @@ import appwardenConfig from "../.appwarden/linked/middleware.json"
 export default createAppwardenMiddleware((cloudflare) =>
   getAppwardenConfiguration(appwardenConfig, {
     appwardenApiToken: cloudflare.env.APPWARDEN_API_TOKEN,
-    lockPageSlug: "/maintenance",
+    website: {
+      lockPageSlug: "/maintenance",
+    },
   }),
 )
 ```
 
 ## Common Mistakes
 
-### HIGH Configuring a lockPageSlug that does not exist as a route
+### HIGH Configuring a website.lockPageSlug that does not exist as a route
 
 Wrong:
 
 ```typescript
-lockPageSlug: "/lockdown"
+website: {
+  lockPageSlug: "/lockdown"
+}
 // but /lockdown is not a real route in the app
 ```
 
 Correct:
 
 ```typescript
-lockPageSlug: "/maintenance"
+website: {
+  lockPageSlug: "/maintenance"
+}
 // with a real /maintenance page in the framework
 ```
 
@@ -132,21 +138,25 @@ Correct:
 
 Appwarden guidance is to use neutral language. Alarming messaging can create unnecessary panic and leak incident details.
 
-### MEDIUM Providing an absolute URL or protocol-relative lockPageSlug
+### MEDIUM Providing an absolute URL or protocol-relative website.lockPageSlug
 
 Wrong:
 
 ```typescript
-lockPageSlug: "https://example.com/maintenance"
+website: {
+  lockPageSlug: "https://example.com/maintenance"
+}
 ```
 
 Correct:
 
 ```typescript
-lockPageSlug: "/maintenance"
+website: {
+  lockPageSlug: "/maintenance"
+}
 ```
 
-`lockPageSlug` must be a relative path. The schema rejects values containing `://`, starting with `//`, or containing backslashes.
+`website.lockPageSlug` must be a relative path. The schema rejects values containing `://`, starting with `//`, or containing backslashes.
 
 ## Next Steps
 

--- a/skills/appwarden-middleware-vercel-edge/references/upstash-kv.md
+++ b/skills/appwarden-middleware-vercel-edge/references/upstash-kv.md
@@ -21,7 +21,9 @@ export default createAppwardenMiddleware(
     {},
     {
       appwardenApiToken: process.env.APPWARDEN_API_TOKEN,
-      lockPageSlug: "/maintenance",
+      website: {
+        lockPageSlug: "/maintenance",
+      },
       cacheUrl: process.env.KV_URL,
       debug: true,
     },

--- a/skills/appwarden-middleware-vercel-edge/references/vercel-edge-config.md
+++ b/skills/appwarden-middleware-vercel-edge/references/vercel-edge-config.md
@@ -22,7 +22,9 @@ export default createAppwardenMiddleware(
     {},
     {
       appwardenApiToken: process.env.APPWARDEN_API_TOKEN,
-      lockPageSlug: "/maintenance",
+      website: {
+        lockPageSlug: "/maintenance",
+      },
       cacheUrl: process.env.EDGE_CONFIG,
       vercelApiToken: process.env.VERCEL_API_TOKEN,
       debug: true,


### PR DESCRIPTION
Updates the skill docs and generated artifacts to reflect the recent input configuration schema changes:

- `lockPageSlug` is now nested under `website` (`website.lockPageSlug`).
- `contentSecurityPolicy` is now nested under `website` as `website.cspMode` and `website.cspDirectives`.
- Updated examples in the CSP, lock page, and getting-started skills.
- Updated Vercel edge references and generated `_artifacts` files to match.

All type checks and tests (956) pass.