### PR TITLE
patch: remove legacy route-based middleware config format

### DIFF
--- a/scripts/appwarden-link.cjs
+++ b/scripts/appwarden-link.cjs
@@ -772,7 +772,7 @@ async function fetchRemoteConfig(apiToken, apiHostname, fqdn) {
       return null
     }
 
-    let config = normalizeRemoteConfigKeys(data)
+    const config = normalizeRemoteConfigKeys(data)
     // Normalize camelCase CSP directive keys inside website.cspDirectives
     // into kebab-case names that the middleware runtime expects.
     if (config.website && config.website.cspDirectives) {

--- a/scripts/appwarden-link.test.ts
+++ b/scripts/appwarden-link.test.ts
@@ -1075,7 +1075,7 @@ describe("appwarden-link.cjs", () => {
     fs.rmSync(tmpDir, { recursive: true })
   })
 
-  it("should handle remote config", () => {
+  it("should coerce remote config debug string to boolean", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "appwarden-test-"))
 
     fs.writeFileSync(


### PR DESCRIPTION
Removes all remaining support for the legacy route-based middleware configuration format (`{ "appwardenMiddleware": [{ "url": "...", "options": { ... } }] }`).

### Changes

- **`scripts/appwarden-link.cjs`**: `fetchRemoteConfig` now strictly expects and processes a flat middleware config object. Removed all extraction/fallback logic for `data.content`, `entry.options`, arrays of service objects, the empty-array sentinel, and the route-based wrapper flattening step.
- **`scripts/appwarden-link.test.ts`**: Updated all mocked API responses to use the flat config shape, and renamed tests that previously referred to "flat fallback" / route-based behavior.
- **`skills/appwarden-middleware-cloudflare-adapters/SKILL.md`**: Updated documentation to describe the flat `middleware.json` configuration.
- **Adapters, runners, and `get-appwarden-configuration.ts`**: Already used the flat schema; no source changes needed.

### Verification

- `npx vitest run` → 946 tests passed
- `npx vitest run --config vitest.node.config.ts` → 37 tests passed
- `npx tsc --noEmit` → no type errors

Note: `build/` outputs contain stale references and will be regenerated on the next build.