### PR TITLE
patch: remove legacy route-based middleware config format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub](https://img.shields.io/badge/GitHub-appwarden%2Fmiddleware-181717?logo=github&logoColor=white)](https://github.com/appwarden/middleware)
 [![npm version](https://img.shields.io/npm/v/@appwarden/middleware.svg)](https://www.npmjs.com/package/@appwarden/middleware)
 [![npm provenance](https://img.shields.io/badge/npm-provenance-green)](https://docs.npmjs.com/generating-provenance-statements)
-![Test Coverage](https://img.shields.io/badge/coverage-91.86%25-brightgreen)
+![Test Coverage](https://img.shields.io/badge/coverage-92.9%25-brightgreen)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 ## Core Features
@@ -31,45 +31,11 @@ Nonce-based CSP requires HTML rewriting and is only available on Cloudflare. Nex
 
 ## Configuration
 
-The following options are shared across the Cloudflare and Vercel middleware bundles.
+The following options are shared across the Cloudflare and Vercel middleware bundles. You must
+provide at least one of `website`, `api`, or `multidomainConfig` (Cloudflare universal only) so
+Appwarden knows which requests to protect.
 
-### `lockPageSlug`
-
-The path or route (for example, `/maintenance`) to redirect users to when the domain is quarantined.
-This should be a working page on your site, such as a maintenance or status page, that
-explains why the website is temporarily unavailable.
-
-### `contentSecurityPolicy` (optional)
-
-Controls the [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) headers that Appwarden adds. This configuration is optional—if not provided, no CSP header will be applied.
-
-When provided, both `mode` and `directives` are required:
-
-- `mode` controls how the CSP is applied:
-  - `"disabled"` – no CSP header is sent.
-  - `"report-only"` – sends the `Content-Security-Policy-Report-Only` header so violations are
-    reported (for example in the browser console) but not blocked.
-  - `"enforced"` – sends the `Content-Security-Policy` header so violations are actively blocked.
-
-  When developing or iterating on your CSP, we recommend starting with `"report-only"` so you can
-  identify and fix violations before switching to `"enforced"`.
-
-- `directives` is an object whose keys are CSP directive names and whose values are
-  arrays of allowed sources. For example:
-
-  ```ts
-  contentSecurityPolicy: {
-    mode: "enforced",
-    directives: {
-      "script-src": ["'self'", "{{nonce}}"],
-      "style-src": ["'self'", "{{nonce}}"],
-    },
-  }
-  ```
-
-To add a nonce to a directive (See [Feature Compatibility](#feature-compatibility)), include the `"{{nonce}}"` placeholder in the list of sources.
-
-### `appwardenApiToken`
+### `appwardenApiToken` (required)
 
 The Appwarden API token used to authenticate requests to the Appwarden API. See the
 [API token management guide](https://appwarden.io/docs/guides/api-token-management) for details on creating and
@@ -78,6 +44,84 @@ managing your token.
 Treat this token as a secret (similar to a password): do not commit it to source control and store
 it in environment variables or secret management where possible. Appwarden stores API tokens using
 AES-GCM encryption and does not display them after creation.
+
+### `debug` (optional)
+
+Defaults to `false`. Set to `true` (or the string `"true"`) during initial setup to log lock checks
+and configuration issues. Disable in production once the integration is stable.
+
+### `appwardenApiHostname` (optional)
+
+Reserved for internal testing. Leave unset to use the production Appwarden API.
+
+### `bypassPaths` (optional)
+
+An array of path patterns that should always pass through without a lock check. Patterns match
+exact paths and subpaths at segment boundaries. A trailing `/*` is optional.
+
+```ts
+bypassPaths: ["/health", "/api/health"]
+```
+
+### `website` (optional)
+
+Configure website quarantine and CSP.
+
+- `lockPageSlug` – relative path to redirect to when the site is locked. Defaults to `/maintenance`.
+- `cspMode` – optional CSP mode: `"disabled"`, `"report-only"`, or `"enforced"`. When omitted, no CSP
+  header is applied.
+- `cspDirectives` – optional CSP directives object, or a JSON string. For example:
+
+  ```ts
+  website: {
+    lockPageSlug: "/maintenance",
+    cspMode: "enforced",
+    cspDirectives: {
+      "script-src": ["'self'", "{{nonce}}"],
+      "style-src": ["'self'", "{{nonce}}"],
+    },
+  }
+  ```
+
+To add a nonce to a directive (see [Feature Compatibility](#feature-compatibility)), include the
+`"{{nonce}}"` placeholder in the list of sources.
+
+### `api` (optional)
+
+Configure API quarantine.
+
+- `basePaths` – array of path patterns to treat as API routes. Defaults to `["/"]`.
+- `response` – optional response to return when an API route is locked:
+  - `status` – defaults to `503`
+  - `body` – defaults to `{"error":"Service unavailable"}`
+  - `headers` – optional array of `{ name, value }`
+
+```ts
+api: {
+  basePaths: ["/api"],
+  response: {
+    status: 503,
+    body: '{"error":"Service unavailable"}',
+    headers: [{ name: "Content-Type", value: "application/json" }],
+  },
+}
+```
+
+### `multidomainConfig` (Cloudflare universal only, optional)
+
+Per-hostname overrides. Each key is a hostname and each value can override `website`, `api`,
+`bypassPaths`, and `debug`. Domain-specific values take precedence over top-level values.
+
+```ts
+multidomainConfig: {
+  "app.example.com": {
+    website: { lockPageSlug: "/maintenance-app" },
+  },
+  "api.example.com": {
+    api: { basePaths: ["/api"] },
+  },
+}
+```
 
 ### `cacheUrl` (Vercel only)
 
@@ -112,12 +156,16 @@ import { createAppwardenMiddleware } from "@appwarden/middleware/cloudflare"
 
 const appwardenHandler = createAppwardenMiddleware((cloudflare) => ({
   debug: cloudflare.env.DEBUG,
-  lockPageSlug: cloudflare.env.APPWARDEN_LOCK_PAGE_SLUG,
   appwardenApiToken: cloudflare.env.APPWARDEN_API_TOKEN,
-  contentSecurityPolicy: {
-    mode: cloudflare.env.CSP_MODE,
-    directives: cloudflare.env.CSP_DIRECTIVES,
+  website: {
+    lockPageSlug: cloudflare.env.APPWARDEN_LOCK_PAGE_SLUG,
+    cspMode: cloudflare.env.CSP_MODE,
+    cspDirectives: cloudflare.env.CSP_DIRECTIVES,
   },
+  api: {
+    basePaths: ["/api"],
+  },
+  bypassPaths: ["/health"],
 }))
 
 export default {
@@ -245,23 +293,35 @@ To use Appwarden as Vercel Edge Middleware, use the `@appwarden/middleware/verce
 
 ```ts
 // middleware.ts (Next.js app on Vercel)
-import { createAppwardenMiddleware } from "@appwarden/middleware/vercel"
+import {
+  createAppwardenMiddleware,
+  getAppwardenConfiguration,
+} from "@appwarden/middleware/vercel"
 
-const appwardenMiddleware = createAppwardenMiddleware({
-  // Edge Config or Upstash KV URL
-  cacheUrl: process.env.APPWARDEN_CACHE_URL!,
-  // Required when using Vercel Edge Config
-  vercelApiToken: process.env.APPWARDEN_VERCEL_API_TOKEN!,
-  appwardenApiToken: process.env.APPWARDEN_API_TOKEN!,
-  lockPageSlug: "/maintenance",
-  contentSecurityPolicy: {
-    // See Configuration > contentSecurityPolicy section for details
-    mode: "report-only",
-    directives: {
-      "default-src": ["'self'"],
+const appwardenMiddleware = createAppwardenMiddleware(
+  getAppwardenConfiguration(
+    {},
+    {
+      // Edge Config or Upstash KV URL
+      cacheUrl: process.env.APPWARDEN_CACHE_URL!,
+      // Required when using Vercel Edge Config
+      vercelApiToken: process.env.APPWARDEN_VERCEL_API_TOKEN!,
+      appwardenApiToken: process.env.APPWARDEN_API_TOKEN!,
+      debug: true,
+      website: {
+        lockPageSlug: "/maintenance",
+        cspMode: "report-only",
+        cspDirectives: {
+          "default-src": ["'self'"],
+        },
+      },
+      api: {
+        basePaths: ["/api"],
+      },
+      bypassPaths: ["/health"],
     },
-  },
-})
+  ),
+)
 
 export default appwardenMiddleware
 ```

--- a/scripts/appwarden-link.cjs
+++ b/scripts/appwarden-link.cjs
@@ -783,8 +783,11 @@ async function fetchRemoteConfig(apiToken, apiHostname, fqdn) {
 
     return sanitizeRemoteConfig(config)
   } catch (err) {
-    if (err.message.startsWith("Authentication failed")) throw err
-    warn(`fetch error: ${href} ${err.message}`)
+    const message = err instanceof Error ? err.message : String(err)
+    if (message.startsWith("Authentication failed")) {
+      throw err instanceof Error ? err : new Error(message)
+    }
+    warn(`fetch error: ${href} ${message}`)
     return null
   } finally {
     clearTimeout(timeout)
@@ -905,7 +908,8 @@ async function main() {
   try {
     remote = await fetchRemoteConfig(apiToken, apiHostname, fqdn)
   } catch (err) {
-    warn(err.message)
+    const message = err instanceof Error ? err.message : String(err)
+    warn(message)
     process.exit(1)
   }
   if (remote) {

--- a/scripts/appwarden-link.cjs
+++ b/scripts/appwarden-link.cjs
@@ -653,13 +653,6 @@ function sanitizeRemoteConfig(data, depth = 0) {
     warn("Remote config nested too deeply. Truncating.")
     return null
   }
-  if (Array.isArray(data) && data.length === 0) {
-    warn(
-      "No Appwarden configuration was found for this domain. Are you sure the configuration exists and is committed to the domain configuration repository?",
-    )
-    return Object.create(null)
-  }
-
   if (!data || typeof data !== "object" || Array.isArray(data)) {
     warn("Remote config response was not a valid object. Ignoring.")
     return null
@@ -773,64 +766,19 @@ async function fetchRemoteConfig(apiToken, apiHostname, fqdn) {
 
     const data = JSON.parse(text)
 
-    // The API returns { content: [{ url, options }] } — extract the config object
-    let config = null
-    let matchedUrl = null
-    if (data && Array.isArray(data.content)) {
-      const entry = data.content.find(
-        (item) =>
-          item.url === fqdn ||
-          item.url === `www.${fqdn}` ||
-          fqdn === `www.${item.url}`,
-      )
-      matchedUrl = entry?.url ?? null
-      config = entry?.options ?? null
-      if (
-        config === null &&
-        entry &&
-        Array.isArray(entry.middleware) &&
-        entry.middleware.length === 0
-      ) {
-        config = []
-      }
-    } else if (data && Array.isArray(data)) {
-      // Fallback: API returned ServiceMiddlewareType[] directly
-      const entry = data.find(
-        (item) =>
-          item.url === fqdn ||
-          item.url === `www.${fqdn}` ||
-          fqdn === `www.${item.url}`,
-      )
-      matchedUrl = entry?.url ?? null
-      config = entry?.options ?? null
-    } else if (data && typeof data === "object" && !Array.isArray(data)) {
-      // Fallback: API returned a flat object directly
-      config = data
-      matchedUrl = fqdn
+    // The API returns a flat middleware configuration object.
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      warn("Remote config response was not a valid flat object. Ignoring.")
+      return null
     }
 
-    if (config) {
-      config = normalizeRemoteConfigKeys(config)
-      // Normalize camelCase CSP directive keys inside website.cspDirectives
-      // into kebab-case names that the middleware runtime expects.
-      if (config.website && config.website.cspDirectives) {
-        config.website.cspDirectives = kebabCaseDirectives(
-          config.website.cspDirectives,
-        )
-      }
-
-      // If the API response uses the route-based options wrapper,
-      // flatten it into the top-level middleware shape.
-      // Preserve any global fields from the API response at the top level.
-      if (config.website || config.api || config.bypassPaths) {
-        const result = { ...config }
-        for (const key of ["debug", "appwardenApiHostname"]) {
-          if (data[key] !== undefined && data[key] !== null) {
-            result[key] = data[key]
-          }
-        }
-        return sanitizeRemoteConfig(result)
-      }
+    let config = normalizeRemoteConfigKeys(data)
+    // Normalize camelCase CSP directive keys inside website.cspDirectives
+    // into kebab-case names that the middleware runtime expects.
+    if (config.website && config.website.cspDirectives) {
+      config.website.cspDirectives = kebabCaseDirectives(
+        config.website.cspDirectives,
+      )
     }
 
     return sanitizeRemoteConfig(config)

--- a/scripts/appwarden-link.test.ts
+++ b/scripts/appwarden-link.test.ts
@@ -525,12 +525,7 @@ describe("appwarden-link.cjs", () => {
       wrapperPath,
       "global.fetch = async () => {\n" +
         "  const bodyText = JSON.stringify({\n" +
-        "    content: [{\n" +
-        '      url: "example.com",\n' +
-        "      options: {\n" +
-        '        website: { lockPageSlug: "/maintenance", cspMode: "invalid-mode" }\n' +
-        "      }\n" +
-        "    }]\n" +
+        '    website: { lockPageSlug: "/maintenance", cspMode: "invalid-mode" }\n' +
         "  });\n" +
         "  return {\n" +
         "    ok: true,\n" +
@@ -590,13 +585,8 @@ describe("appwarden-link.cjs", () => {
       wrapperPath,
       "global.fetch = async () => {\n" +
         "  const bodyText = JSON.stringify({\n" +
-        "    content: [{\n" +
-        '      url: "example.com",\n' +
-        "      options: {\n" +
-        '        website: { lockPageSlug: "/maintenance" },\n' +
-        '        appwardenApiHostname: "https://evil.com"\n' +
-        "      }\n" +
-        "    }]\n" +
+        '    website: { lockPageSlug: "/maintenance" },\n' +
+        '    appwardenApiHostname: "https://evil.com"\n' +
         "  });\n" +
         "  return {\n" +
         "    ok: true,\n" +
@@ -652,13 +642,8 @@ describe("appwarden-link.cjs", () => {
       wrapperPath,
       "global.fetch = async () => {\n" +
         "  const bodyText = JSON.stringify({\n" +
-        "    content: [{\n" +
-        '      url: "example.com",\n' +
-        "      options: {\n" +
-        '        website: { lockPageSlug: "/maintenance" },\n' +
-        '        appwardenApiHostname: "https://staging-api.appwarden.io"\n' +
-        "      }\n" +
-        "    }]\n" +
+        '    website: { lockPageSlug: "/maintenance" },\n' +
+        '    appwardenApiHostname: "https://staging-api.appwarden.io"\n' +
         "  });\n" +
         "  return {\n" +
         "    ok: true,\n" +
@@ -736,13 +721,8 @@ describe("appwarden-link.cjs", () => {
       wrapperPath,
       "global.fetch = async () => {\n" +
         "  const bodyText = JSON.stringify({\n" +
-        "    content: [{\n" +
-        '      url: "example.com",\n' +
-        "      options: {\n" +
-        '        website: { lockPageSlug: "/maintenance" },\n' +
-        '        appwardenApiHostname: "http://api.appwarden.io"\n' +
-        "      }\n" +
-        "    }]\n" +
+        '    website: { lockPageSlug: "/maintenance" },\n' +
+        '    appwardenApiHostname: "http://api.appwarden.io"\n' +
         "  });\n" +
         "  return {\n" +
         "    ok: true,\n" +
@@ -840,12 +820,7 @@ describe("appwarden-link.cjs", () => {
       wrapperPath,
       "global.fetch = async () => {\n" +
         "  const bodyText = JSON.stringify({\n" +
-        "    content: [{\n" +
-        '      url: "example.com",\n' +
-        "      options: {\n" +
-        '        website: { lockPageSlug: "https://evil.com" },\n' +
-        "      }\n" +
-        "    }]\n" +
+        '    website: { lockPageSlug: "https://evil.com" },\n' +
         "  });\n" +
         "  return {\n" +
         "    ok: true,\n" +
@@ -1017,7 +992,7 @@ describe("appwarden-link.cjs", () => {
     fs.rmSync(tmpDir, { recursive: true })
   })
 
-  it("should parse and write flat remote config", () => {
+  it("should parse and write remote config", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "appwarden-test-"))
 
     fs.writeFileSync(
@@ -1030,26 +1005,21 @@ describe("appwarden-link.cjs", () => {
       wrapperPath,
       "global.fetch = async () => {\n" +
         "  const bodyText = JSON.stringify({\n" +
-        "    content: [{\n" +
-        '      url: "example.com",\n' +
-        "      options: {\n" +
-        '        debug: "true",\n' +
-        '        "bypass-paths": ["/health", "/api/webhooks/*"],\n' +
-        "        website: {\n" +
-        '          "lock-page-slug": "/maintenance",\n' +
-        '          "csp-mode": "report-only",\n' +
-        '          "csp-directives": { "default-src": ["\'self\'"] }\n' +
-        "        },\n" +
-        "        api: {\n" +
-        '          "base-paths": ["/api", "/internal"],\n' +
-        "          response: {\n" +
-        "            status: 503,\n" +
-        '            body: "{\\"error\\":\\"Service unavailable\\"}",\n' +
-        '            headers: [{ name: "content-type", value: "application/json" }]\n' +
-        "          }\n" +
-        "        }\n" +
+        '    debug: "true",\n' +
+        '    "bypass-paths": ["/health", "/api/webhooks/*"],\n' +
+        "    website: {\n" +
+        '      "lock-page-slug": "/maintenance",\n' +
+        '      "csp-mode": "report-only",\n' +
+        '      "csp-directives": { "default-src": ["\'self\'"] }\n' +
+        "    },\n" +
+        "    api: {\n" +
+        '      "base-paths": ["/api", "/internal"],\n' +
+        "      response: {\n" +
+        "        status: 503,\n" +
+        '        body: "{\\"error\\":\\"Service unavailable\\"}",\n' +
+        '        headers: [{ name: "content-type", value: "application/json" }]\n' +
         "      }\n" +
-        "    }]\n" +
+        "    }\n" +
         "  });\n" +
         "  const encoder = new TextEncoder();\n" +
         "  return {\n" +
@@ -1105,7 +1075,7 @@ describe("appwarden-link.cjs", () => {
     fs.rmSync(tmpDir, { recursive: true })
   })
 
-  it("should handle flat object fallback", () => {
+  it("should handle remote config", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "appwarden-test-"))
 
     fs.writeFileSync(
@@ -1189,13 +1159,8 @@ describe("appwarden-link.cjs", () => {
       wrapperPath,
       "global.fetch = async () => {\n" +
         "  const bodyText = JSON.stringify({\n" +
-        "    content: [{\n" +
-        '      url: "example.com",\n' +
-        "      options: {\n" +
-        '        debug: "invalid",\n' +
-        '        website: { lockPageSlug: "/maintenance" }\n' +
-        "      }\n" +
-        "    }]\n" +
+        '    debug: "invalid",\n' +
+        '    website: { lockPageSlug: "/maintenance" }\n' +
         "  });\n" +
         "  return {\n" +
         "    ok: true,\n" +
@@ -1251,18 +1216,13 @@ describe("appwarden-link.cjs", () => {
       wrapperPath,
       "global.fetch = async () => {\n" +
         "  const bodyText = JSON.stringify({\n" +
-        "    content: [{\n" +
-        '      url: "example.com",\n' +
-        "      options: {\n" +
-        "        api: {\n" +
-        '          basePaths: ["/api"],\n' +
-        "          response: {\n" +
-        "            status: 503,\n" +
-        '            body: "\\"locked\\""\n' +
-        "          }\n" +
-        "        }\n" +
+        "    api: {\n" +
+        '      basePaths: ["/api"],\n' +
+        "      response: {\n" +
+        "        status: 503,\n" +
+        '        body: "\\"locked\\""\n' +
         "      }\n" +
-        "    }]\n" +
+        "    }\n" +
         "  });\n" +
         "  return {\n" +
         "    ok: true,\n" +
@@ -1304,7 +1264,7 @@ describe("appwarden-link.cjs", () => {
     fs.rmSync(tmpDir, { recursive: true })
   })
 
-  it("preserves top-level fields alongside flat route config", () => {
+  it("preserves top-level fields in remote config", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "appwarden-test-"))
 
     fs.writeFileSync(
@@ -1319,14 +1279,9 @@ describe("appwarden-link.cjs", () => {
         "  const bodyText = JSON.stringify({\n" +
         '    debug: "true",\n' +
         '    appwardenApiHostname: "https://api.appwarden.io",\n' +
-        "    content: [{\n" +
-        '      url: "example.com",\n' +
-        "      options: {\n" +
-        "        website: {\n" +
-        '          lockPageSlug: "/maintenance"\n' +
-        "        }\n" +
-        "      }\n" +
-        "    }]\n" +
+        "    website: {\n" +
+        '      lockPageSlug: "/maintenance"\n' +
+        "    }\n" +
         "  });\n" +
         "  return {\n" +
         "    ok: true,\n" +

--- a/scripts/appwarden-link.test.ts
+++ b/scripts/appwarden-link.test.ts
@@ -1146,6 +1146,41 @@ describe("appwarden-link.cjs", () => {
     fs.rmSync(tmpDir, { recursive: true })
   })
 
+  it("should handle a non-Error thrown by fetch without crashing", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "appwarden-test-"))
+
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ dependencies: { next: "^14" } }),
+    )
+
+    const wrapperPath = path.join(tmpDir, "mock-fetch-wrapper.cjs")
+    fs.writeFileSync(
+      wrapperPath,
+      "global.fetch = async () => {\n" +
+        "  throw 'network error';\n" +
+        "};\n" +
+        'process.env.APPWARDEN_API_TOKEN = "test-token";\n' +
+        'process.env.APPWARDEN_FQDN = "example.com";\n' +
+        'require("' +
+        scriptPath +
+        '");\n',
+    )
+
+    execSync(`node "${wrapperPath}"`, {
+      cwd: tmpDir,
+      encoding: "utf-8",
+      env: { ...process.env, APPWARDEN_SKIP_POSTBUILD: undefined },
+    })
+
+    const configPath = path.join(tmpDir, configDir, configName)
+    const config = JSON.parse(fs.readFileSync(configPath, "utf-8"))
+
+    expect(config.website.lockPageSlug).toBe("/maintenance")
+
+    fs.rmSync(tmpDir, { recursive: true })
+  })
+
   it("should reject invalid debug string values", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "appwarden-test-"))
 

--- a/skills/appwarden-middleware-cloudflare-adapters/SKILL.md
+++ b/skills/appwarden-middleware-cloudflare-adapters/SKILL.md
@@ -43,7 +43,7 @@ npm install @appwarden/middleware
 
 ### New configuration format
 
-The Cloudflare adapters use the nested `middleware.options` configuration. Runtime call-site values can override or extend the generated `middleware.json`:
+The Cloudflare adapters use the flat `middleware.json` configuration. Runtime call-site values can override or extend the generated `middleware.json`:
 
 ```typescript
 getAppwardenConfiguration(appwardenConfig, {

--- a/src/middlewares/use-appwarden.test.ts
+++ b/src/middlewares/use-appwarden.test.ts
@@ -486,4 +486,126 @@ describe("useAppwarden", () => {
       expect(mockNext).toHaveBeenCalled()
     })
   })
+
+  describe("middleware action control flow", () => {
+    it("should bypass lock check and still call next() when action is bypass", async () => {
+      vi.mocked(resolveMiddlewareAction).mockReturnValue("bypass")
+
+      const middleware = useAppwarden(mockInput)
+      await middleware(mockContext, mockNext)
+
+      expect(checkLockStatus).not.toHaveBeenCalled()
+      expect(mockNext).toHaveBeenCalledTimes(1)
+    })
+
+    it("should return configured API lock response and not call next() when API path is locked", async () => {
+      vi.mocked(resolveMiddlewareAction).mockReturnValue("api")
+      vi.mocked(checkLockStatus).mockResolvedValue({
+        isLocked: true,
+        isTestLock: false,
+      })
+
+      const inputWithApi: CloudflareConfigType = {
+        ...mockInput,
+        api: {
+          basePaths: ["/api"],
+          response: {
+            status: 503,
+            body: '{"error":"Service unavailable"}',
+            headers: [{ name: "X-Custom-Header", value: "locked" }],
+          },
+        },
+      }
+
+      const middleware = useAppwarden(inputWithApi)
+      await middleware(mockContext, mockNext)
+
+      expect(checkLockStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: mockContext.request,
+          lockPageSlug: mockInput.website?.lockPageSlug,
+        }),
+      )
+      expect(mockContext.response).toBeInstanceOf(Response)
+      expect(mockContext.response!.status).toBe(503)
+      expect(await mockContext.response!.text()).toBe(
+        '{"error":"Service unavailable"}',
+      )
+      expect(mockContext.response!.headers.get("X-Custom-Header")).toBe(
+        "locked",
+      )
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+
+    it("should call next() when API path is unlocked", async () => {
+      vi.mocked(resolveMiddlewareAction).mockReturnValue("api")
+      vi.mocked(checkLockStatus).mockResolvedValue({
+        isLocked: false,
+        isTestLock: false,
+      })
+
+      const inputWithApi: CloudflareConfigType = {
+        ...mockInput,
+        api: {
+          basePaths: ["/api"],
+        } as any,
+      }
+
+      const middleware = useAppwarden(inputWithApi)
+      await middleware(mockContext, mockNext)
+
+      expect(checkLockStatus).toHaveBeenCalled()
+      expect(mockNext).toHaveBeenCalledTimes(1)
+    })
+
+    it("should use default API lock response when api.response is not configured", async () => {
+      vi.mocked(resolveMiddlewareAction).mockReturnValue("api")
+      vi.mocked(checkLockStatus).mockResolvedValue({
+        isLocked: true,
+        isTestLock: false,
+      })
+
+      const inputWithApi: CloudflareConfigType = {
+        ...mockInput,
+        api: {
+          basePaths: ["/api"],
+        } as any,
+      }
+
+      const middleware = useAppwarden(inputWithApi)
+      await middleware(mockContext, mockNext)
+
+      expect(mockContext.response).toBeInstanceOf(Response)
+      expect(mockContext.response!.status).toBe(503)
+      expect(await mockContext.response!.text()).toBe(
+        '{"error":"Service unavailable"}',
+      )
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+
+    it("should wrap context.waitUntil for API lock checks", async () => {
+      vi.mocked(resolveMiddlewareAction).mockReturnValue("api")
+      vi.mocked(checkLockStatus).mockResolvedValue({
+        isLocked: false,
+        isTestLock: false,
+      })
+
+      const inputWithApi: CloudflareConfigType = {
+        ...mockInput,
+        api: {
+          basePaths: ["/api"],
+        } as any,
+      }
+
+      const middleware = useAppwarden(inputWithApi)
+      await middleware(mockContext, mockNext)
+
+      const callArgs = vi.mocked(checkLockStatus).mock.calls[0][0]
+      const waitUntilFn = callArgs.waitUntil
+      const testPromise = Promise.resolve()
+      waitUntilFn(testPromise)
+
+      expect(mockContext.waitUntil).toHaveBeenCalledWith(testPromise)
+    })
+  })
 })

--- a/src/schemas/middleware-options.test.ts
+++ b/src/schemas/middleware-options.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+import {
+  MiddlewareOptionsSchema,
+  PathPatternSchema,
+  WebsiteMiddlewareConfigSchema,
+} from "./middleware-options"
+
+describe("PathPatternSchema", () => {
+  it.each(["/api", "/api/*", "/api/users/123", "/"])(
+    "accepts a valid path pattern: %s",
+    (pattern) => {
+      expect(PathPatternSchema.safeParse(pattern).success).toBe(true)
+    },
+  )
+
+  it.each([
+    "api",
+    "https://example.com/api",
+    "/api?query=1",
+    "/api#fragment",
+    "",
+  ])("rejects an invalid path pattern: %s", (pattern) => {
+    const result = PathPatternSchema.safeParse(pattern)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain(
+        "Path pattern must be a valid absolute path starting with /",
+      )
+    }
+  })
+})
+
+describe("WebsiteMiddlewareConfigSchema", () => {
+  it("rejects an invalid JSON string for cspDirectives", () => {
+    const result = WebsiteMiddlewareConfigSchema.safeParse({
+      lockPageSlug: "/maintenance",
+      cspDirectives: '{"default-src": ["\'self\'"}',
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain(
+        "Failed to parse `CSP_DIRECTIVES`",
+      )
+    }
+  })
+})
+
+describe("MiddlewareOptionsSchema", () => {
+  it("rejects invalid bypassPaths", () => {
+    const result = MiddlewareOptionsSchema.safeParse({
+      bypassPaths: ["api", "/api?query=1"],
+    })
+
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
- `appwarden-link.cjs` now expects and writes a flat middleware config object
- removed all `data.content` / `entry.options` / array-of-service fallbacks
- removed empty-array sentinel and route-based wrapper flattening
- updated `appwarden-link` tests to mock flat config responses
- updated skill docs to describe flat `middleware.json` format
- updated README with new `website`/`api`/`multidomainConfig` option structure
- added tests for `middleware-options` schema and `use-appwarden` flat config behavior