### PR TITLE
fix(heartbeat): revert heartbeat contract version to 1

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@ export const APPWARDEN_TEST_ROUTE = "/_appwarden/test"
 
 export const APPWARDEN_HEARTBEAT_ROUTE = "/_appwarden/heartbeat"
 
-export const HEARTBEAT_CONTRACT_VERSION = 2 as const
+export const HEARTBEAT_CONTRACT_VERSION = 1 as const
 
 export const HEARTBEAT_VERSION_MAX_LENGTH = 128
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,7 +18,7 @@ describe("index exports", () => {
   })
 
   it("should export heartbeat contract version constant", () => {
-    expect(indexExports.HEARTBEAT_CONTRACT_VERSION).toBe(2)
+    expect(indexExports.HEARTBEAT_CONTRACT_VERSION).toBe(1)
   })
 
   it("should export heartbeat version max length constant", () => {


### PR DESCRIPTION
Reverts `HEARTBEAT_CONTRACT_VERSION` from `2` back to `1` and updates the corresponding test expectation.